### PR TITLE
Added checks for liveness and readiness probes

### DIFF
--- a/policy/kubernetes/README.md
+++ b/policy/kubernetes/README.md
@@ -21,6 +21,8 @@
 |K8S_17|DENY|Sharing Host PID namespace|
 |K8S_18|DENY|Sharing Host Network namespace|
 |K8S_19|DENY|Running as user id that is too low|
+|K8S_20|WARN|Missing liveness probes|
+|K8S_21|WARN|Missing readiness probes|
 
 ## Make an exception
 

--- a/policy/kubernetes/warn_liveness_probe.rego
+++ b/policy/kubernetes/warn_liveness_probe.rego
@@ -1,0 +1,21 @@
+package kubernetes
+
+import data.kubernetes
+
+# DENY(K8S_20): Liveness probes
+# Description:
+# Links:
+#
+check20 := "K8S_20"
+
+exception[rules] {
+    make_exception(check20)
+    rules = ["liveness_probes"]
+}
+
+warn_liveness_probes[msg] {
+	is_workload
+	kubernetes.containers[container]
+	not container.livenessProbe
+	msg = sprintf("%s: %s in the %s %s does not have a liveness probe", [check20, container.name, kubernetes.kind, kubernetes.name])
+}

--- a/policy/kubernetes/warn_liveness_probe_test.rego
+++ b/policy/kubernetes/warn_liveness_probe_test.rego
@@ -1,0 +1,113 @@
+package kubernetes
+
+test_warn_liveness_probes {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "containers": [
+                        {
+                            "image":"org/image:latest",
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    warn_liveness_probes with input as input
+}
+
+test_warn_liveness_probes_init_container {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "initContainers": [
+                        {
+                            "image":"org/image:latest",
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    warn_liveness_probes with input as input
+}
+
+test_not_warn_liveness_probes {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "containers": [
+                        {
+                            "name":"test",
+                            "image":"org/image:latest",
+                            "resources": {
+                                "limits": {
+                                    "memory":"500m"
+                                }
+                            },
+                            "livenessProbe": {
+                                "exec": {
+                                    "command": ["cat", "/tmp/healthy"]
+                                },
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    not warn_liveness_probes["K8S_20: test in the Deployment sample does not have a liveness probe"] with input as input
+}

--- a/policy/kubernetes/warn_readiness_probe.rego
+++ b/policy/kubernetes/warn_readiness_probe.rego
@@ -1,0 +1,21 @@
+package kubernetes
+
+import data.kubernetes
+
+# DENY(K8S_21): Readiness probes
+# Description:
+# Links:
+#
+check21 := "K8S_21"
+
+exception[rules] {
+    make_exception(check21)
+    rules = ["readiness_probes"]
+}
+
+warn_readiness_probes[msg] {
+	is_workload
+	kubernetes.containers[container]
+	not container.readinessProbe
+	msg = sprintf("%s: %s in the %s %s does not have a readiness probe", [check21, container.name, kubernetes.kind, kubernetes.name])
+}

--- a/policy/kubernetes/warn_readiness_probe_test.rego
+++ b/policy/kubernetes/warn_readiness_probe_test.rego
@@ -1,0 +1,113 @@
+package kubernetes
+
+test_warn_readiness_probes {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "containers": [
+                        {
+                            "image":"org/image:latest",
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    warn_readiness_probes with input as input
+}
+
+test_warn_readiness_probes_init_container {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "initContainers": [
+                        {
+                            "image":"org/image:latest",
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    warn_memory_limits with input as input
+}
+
+test_not_warn_readiness_probes {
+  input := {
+        "kind": "Deployment",
+        "metadata": {
+            "name": "sample",
+            "namespace":"test",
+        },
+        "spec": {
+            "selector": {
+                "matchLabels": {
+                    "app": "app",
+                    "release": "release"
+                }
+            },
+            "template": {
+                "spec": {
+                    "securityContext": {
+                        "runAsNonRoot": true,
+                    },
+                    "serviceAccountName": "test",
+                    "containers": [
+                        {
+                            "name":"test",
+                            "image":"org/image:latest",
+                            "resources": {
+                                "limits": {
+                                    "memory":"500m"
+                                }
+                            },
+                            "readinessProbe": {
+                                "exec": {
+                                    "command": ["cat", "/tmp/healthy"]
+                                },
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    not warn_readiness_probes["K8S_21: test in the Deployment sample does not have a readiness probe"] with input as input
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Added checks that warns if there are no liveness or readiness probes on containers in a workload. 

### Related Issues

List related issues here
