### PR TITLE
Add Agones GameServer as a kubernetes workload type

### DIFF
--- a/policy/kubernetes/kubernetes.rego
+++ b/policy/kubernetes/kubernetes.rego
@@ -13,6 +13,7 @@ is_service = kind == "Service"
 is_workload = any([
 	kind == "DaemonSet",
 	kind == "Deployment",
+	kind == "GameServer",
 	kind == "StatefulSet",
 	kind == "ReplicaSet",
 	kind == "ReplicationController",


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Since GameServer has a similar template to Deployment we can reuse all
the same lint checks so this adds GameServer as a workload to the
kubernetes policy.

