### PR TITLE
Use only one executable to build the `opa fmt` command

### DIFF
--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-find . -type f -name "*.rego" | grep -v "_test" | xargs -I{} opa fmt -w {}
+find . -type f -name "*.rego" -a -not -name "*_test*" -exec opa fmt -w {} \;


### PR DESCRIPTION
Use `find` instead of `grep` to exclude files and `xargs` to build the
executable command line.

### Checklist

* [x] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Super tiny nit to only use one instead of three processes to build the `opa fmt` command.

### Related Issues

No issue, just noticed this could be all done with `find`.