### PR TITLE
Check runAsRoot on both pod and container levels

### DIFF
--- a/policy/kubernetes/deny_run_as_root.rego
+++ b/policy/kubernetes/deny_run_as_root.rego
@@ -14,9 +14,15 @@ exception[rules] {
 	rules = ["run_container_as_root"]
 }
 
-# TODO also check the containers security context, as that takes precedence
+podOrContainerRunningAsRoot(pod) {
+	not pod.spec.securityContext.runAsNonRoot
+	containers := kubernetes.pod_containers(pod)
+	container := containers[_]
+	not container.securityContext.runAsNonRoot
+}
+
 deny_run_container_as_root[msg] {
 	kubernetes.pods[pod]
-	not pod.spec.securityContext.runAsNonRoot
+	podOrContainerRunningAsRoot(pod)
 	msg = sprintf("%s: %s %s is running as root. More info: %s", [check02, kubernetes.kind, kubernetes.name, l.get_url(check02)])
 }

--- a/policy/kubernetes/deny_run_as_root_test.rego
+++ b/policy/kubernetes/deny_run_as_root_test.rego
@@ -2,40 +2,135 @@ package kubernetes
 
 import data.testing as t
 
-basic_deployment := {
-    "kind": "Deployment",
-    "metadata": {
-        "name": "sample",
-        "namespace":"test",
-    },
-    "spec": {
-        "selector": {
-            "matchLabels": {
-                "app": "app",
-                "release": "release"
-            }
-        },
-        "template": {
-            "spec": {
-                "serviceAccountName": "sample",
-            }
-        }
-    }
-}
-
-securityContext_patch := {
-    "op": "add",
-    "path": "/spec/template/spec/securityContext",
-    "value": {
-        "runAsNonRoot": true
-    }
-}
-
 test_deny_deployment_without_security_context {
-  t.error_count(deny_run_container_as_root, 1) with input as basic_deployment
+  input := {
+      "kind": "Deployment",
+      "metadata": {
+          "name": "sample",
+          "namespace":"test",
+      },
+      "spec": {
+          "selector": {
+              "matchLabels": {
+                  "app": "app",
+                  "release": "release"
+              }
+          },
+          "template": {
+              "spec": {
+                  "serviceAccountName": "sample",
+                  "containers": [
+                      {
+                          "name": "test",
+                          "image": "test",
+                      }
+                  ]
+              }
+          }
+      }
+  }
+  t.error_count(deny_run_container_as_root, 1) with input as input
 }
 
-test_allow_deployment_with_security_context {
-  withRunAsNonRoot := json.patch(basic_deployment, [securityContext_patch])
-  t.no_errors(deny_run_container_as_root) with input as withRunAsNonRoot
+test_allow_deployment_with_pod_security_context {
+  input := {
+      "kind": "Deployment",
+      "metadata": {
+          "name": "sample",
+          "namespace":"test",
+      },
+      "spec": {
+          "selector": {
+              "matchLabels": {
+                  "app": "app",
+                  "release": "release"
+              }
+          },
+          "template": {
+              "spec": {
+                  "serviceAccountName": "sample",
+                  "securityContext": {
+                      "runAsNonRoot": true,
+                  },
+                  "containers": [
+                      {
+                          "name": "test",
+                          "image": "test",
+                      }
+                  ]
+              }
+          }
+      }
+  }
+  t.no_errors(deny_run_container_as_root) with input as input
+}
+
+test_allow_deployment_with_container_security_context {
+  input := {
+      "kind": "Deployment",
+      "metadata": {
+          "name": "sample",
+          "namespace":"test",
+      },
+      "spec": {
+          "selector": {
+              "matchLabels": {
+                  "app": "app",
+                  "release": "release"
+              }
+          },
+          "template": {
+              "spec": {
+                  "serviceAccountName": "sample",
+                  "containers": [
+                      {
+                          "name": "test",
+                          "image": "test",
+                          "securityContext": {
+                              "runAsNonRoot": true,
+                          },
+                      }
+                  ]
+              }
+          }
+      }
+  }
+  t.no_errors(deny_run_container_as_root) with input as input
+}
+
+test_deny_deployment_with_partial_container_security_context {
+  input := {
+      "kind": "Deployment",
+      "metadata": {
+          "name": "sample",
+          "namespace":"test",
+      },
+      "spec": {
+          "selector": {
+              "matchLabels": {
+                  "app": "app",
+                  "release": "release"
+              }
+          },
+          "template": {
+              "spec": {
+                  "serviceAccountName": "sample",
+                  "containers": [
+                      {
+                          "name": "test",
+                          "image": "test",
+                          "securityContext": {
+                              "runAsNonRoot": true,
+                          },
+                      },
+                      {
+                          "name": "test",
+                          "image": "test",
+                      }
+                  ]
+              }
+          }
+      }
+  }
+  t.error_count(deny_run_container_as_root, 1) with input as input
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If `runAsNonRoot` is not defined on the pod level, we should still allow a pod
that specifies `runAsNonRoot: true` on all containers

### Related Issues

None