### PR TITLE
Accommodate for new workload_metadata_config field

### DIFF
--- a/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes.rego
+++ b/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes.rego
@@ -5,12 +5,18 @@ import data.terraform
 
 check25 := "TF_GCP_25"
 
-pool_node_metadata := "GKE_METADATA_SERVER"
+deprecated_allowed_value := "GKE_METADATA_SERVER"
+new_allowed_value := "GKE_METADATA"
 
 gke_workloadidentity_nodes_disabled(node_pool) {
-	not node_pool.node_config.workload_metadata_config.node_metadata
+	node_pool.node_config.workload_metadata_config.mode
+	node_pool.node_config.workload_metadata_config.mode != new_allowed_value
 } else {
-	node_pool.node_config.workload_metadata_config.node_metadata != pool_node_metadata
+	node_pool.node_config.workload_metadata_config.node_metadata
+	node_pool.node_config.workload_metadata_config.node_metadata != deprecated_allowed_value
+} else {
+	not node_pool.node_config.workload_metadata_config.mode
+	not node_pool.node_config.workload_metadata_config.node_metadata
 }
 
 # DENY(TF_GCP_25) - google_container_node_pool

--- a/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes_test.rego
@@ -6,12 +6,21 @@ test_not_deny_workloadidentity_nodes {
     input := {
         "resource": {
             "google_container_node_pool": {
-                "test": {
+                "test1": {
                     "cluster": "cluster1",              
-                    "name": "test",
+                    "name": "test1",
                     "node_config": {
                         "workload_metadata_config": {
-                          "node_metadata": pool_node_metadata
+                          "node_metadata": "GKE_METADATA_SERVER",
+                        }
+                    }
+                },
+                "test2": {
+                    "cluster": "cluster2",              
+                    "name": "test2",
+                    "node_config": {
+                        "workload_metadata_config": {
+                          "mode": "GKE_METADATA",
                         }
                     }
                 }
@@ -60,12 +69,21 @@ test_deny_workloadidentity_nodes_unspecified {
     input := {
         "resource": {
             "google_container_node_pool": {
-                "test": {
+                "test1": {
                     "cluster": "cluster1",
-                    "name": "test",
+                    "name": "test1",
                     "node_config": {
                         "workload_metadata_config": {
                           "node_metadata": "UNSPECIFIED"
+                        }
+                    }
+                },
+                "test2": {
+                    "cluster": "cluster2",
+                    "name": "test2",
+                    "node_config": {
+                        "workload_metadata_config": {
+                          "mode": "UNSPECIFIED"
                         }
                     }
                 }
@@ -73,6 +91,6 @@ test_deny_workloadidentity_nodes_unspecified {
         }
     }
 
-    t.error_count(deny_gke_workloadidentity_nodes_disabled, 1) with input as input
+    t.error_count(deny_gke_workloadidentity_nodes_disabled, 2) with input as input
 }
 


### PR DESCRIPTION
The old `node_metadata` has been deprecated in favor of `mode`
