### PR TITLE
feat(policy): migrate policies to Rego v1 syntax

### DIFF
--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -5,6 +5,6 @@ branding:
   color: "green"
 runs:
   using: 'docker'
-  image: 'docker://openpolicyagent/conftest:v0.24.0'
+  image: 'docker://openpolicyagent/conftest:v0.60.0'
   args:
   - verify

--- a/policy/docker/deny_curl_bashing.rego
+++ b/policy/docker/deny_curl_bashing.rego
@@ -1,17 +1,19 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check06 := "DOCKER_06"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check06)
 	rules = ["curl_bashing"]
 }
 
 # DENY(DOCKER_06): Avoid curl bashing, use a trusted source and verify hash
-deny_curl_bashing[msg] {
+deny_curl_bashing contains msg if {
 	docker.runs[run]
 	regex.match("(curl|wget).*[|>].*", lower(run))
 	msg = sprintf("%s: Avoid curl/wget bashing (%s). More info: %s", [check06, run, l.get_url(check06)])

--- a/policy/docker/deny_curl_bashing_test.rego
+++ b/policy/docker/deny_curl_bashing_test.rego
@@ -1,8 +1,10 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_avoid_curl_bashing {
+test_avoid_curl_bashing if {
 	curl_bash := [
 		{
 			"Cmd": "run",
@@ -23,16 +25,14 @@ test_avoid_curl_bashing {
 	t.error_count(deny_curl_bashing, 2) with input as curl_bash
 }
 
-test_allow_curl_without_pipe {
-	curl_bash := [
-		{
-			"Cmd": "run",
-			"Flags": [],
-			"JSON": false,
-			"SubCmd": "",
-			"Value": ["curl", "https://some-url.com"],
-		},
-	]
+test_allow_curl_without_pipe if {
+	curl_bash := [{
+		"Cmd": "run",
+		"Flags": [],
+		"JSON": false,
+		"SubCmd": "",
+		"Value": ["curl", "https://some-url.com"],
+	}]
 
 	t.no_errors(deny_curl_bashing) with input as curl_bash
 }

--- a/policy/docker/deny_not_specifying_user.rego
+++ b/policy/docker/deny_not_specifying_user.rego
@@ -1,17 +1,19 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check01 := "DOCKER_01"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check01)
 	rules = ["no_user"]
 }
 
 # DENY(DOCKER_01): if USER is not specified in the Dockerfile it will use root implicitly
-deny_no_user[msg] {
+deny_no_user contains msg if {
 	not is_user
 	msg = sprintf("%s: Please specify a USER, root is not permitted. More info: %s", [check01, l.get_url(check01)])
 }

--- a/policy/docker/deny_not_specifying_user_test.rego
+++ b/policy/docker/deny_not_specifying_user_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_no_user {
-	input := [
+test_deny_no_user if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -20,5 +22,5 @@ test_deny_no_user {
 		},
 	]
 
-	t.error_count(deny_no_user, 1) with input as input
+	t.error_count(deny_no_user, 1) with input as inp
 }

--- a/policy/docker/deny_port_out_of_range.rego
+++ b/policy/docker/deny_port_out_of_range.rego
@@ -1,22 +1,25 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check07 := "DOCKER_07"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check07)
 	rules = ["port_out_of_range"]
 }
 
 # DENY(DOCKER_07): Port number out of range - https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
-port_in_range {
+port_in_range if {
 	docker.exposes[expose]
-	all([to_number(expose) > 0, to_number(expose) < 65535])
+	to_number(expose) > 0
+	to_number(expose) < 65535
 }
 
-deny_port_out_of_range[msg] {
+deny_port_out_of_range contains msg if {
 	docker.exposes[expose]
 	not port_in_range
 	msg = sprintf("%s: Port number out of range (0-65535). More info: %s", [check07, l.get_url(check07)])

--- a/policy/docker/deny_port_out_of_range_test.rego
+++ b/policy/docker/deny_port_out_of_range_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_port_out_of_range {
-	input := [
+test_port_out_of_range if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -20,5 +22,5 @@ test_port_out_of_range {
 		},
 	]
 
-	t.error_count(deny_port_out_of_range, 1) with input as input
+	t.error_count(deny_port_out_of_range, 1) with input as inp
 }

--- a/policy/docker/deny_sudo_usage.rego
+++ b/policy/docker/deny_sudo_usage.rego
@@ -1,17 +1,19 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check04 := "DOCKER_04"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check04)
 	rules = ["sudo_usage"]
 }
 
 # DENY(DOCKER_04): Do not allow usage of sudo
-deny_sudo_usage[msg] {
+deny_sudo_usage contains msg if {
 	docker.runs[run]
 	contains(lower(run), "sudo")
 	msg = sprintf("%s: Avoid using 'sudo' command (%s). More info: %s", [check04, run, l.get_url(check04)])

--- a/policy/docker/deny_sudo_usage_test.rego
+++ b/policy/docker/deny_sudo_usage_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_sudo_usage {
-	input := [
+test_deny_sudo_usage if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -20,5 +22,5 @@ test_deny_sudo_usage {
 		},
 	]
 
-	t.error_count(deny_sudo_usage, 1) with input as input
+	t.error_count(deny_sudo_usage, 1) with input as inp
 }

--- a/policy/docker/deny_using_add.rego
+++ b/policy/docker/deny_using_add.rego
@@ -1,17 +1,19 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check05 := "DOCKER_05"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check05)
 	rules = ["using_add"]
 }
 
 # DENY(DOCKER_05): Use ADD instead of COPY - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
-deny_using_add[msg] {
+deny_using_add contains msg if {
 	docker.adds[add]
 	msg = sprintf("%s: Use COPY instead of ADD. More info: %s", [check05, l.get_url(check05)])
 }

--- a/policy/docker/deny_using_add_test.rego
+++ b/policy/docker/deny_using_add_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_using_add {
-	input := [
+test_deny_using_add if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -20,5 +22,5 @@ test_deny_using_add {
 		},
 	]
 
-	t.error_count(deny_using_add, 1) with input as input
+	t.error_count(deny_using_add, 1) with input as inp
 }

--- a/policy/docker/deny_using_root_alias.rego
+++ b/policy/docker/deny_using_root_alias.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
-root_alias = [
+root_alias := [
 	"root",
 	"toor",
 	"0",
@@ -11,13 +13,13 @@ root_alias = [
 
 check02 := "DOCKER_02"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check02)
 	rules = ["root_alias"]
 }
 
 # DENY(DOCKER_02): if USER is set to any of the possible root users
-deny_root_alias[msg] {
+deny_root_alias contains msg if {
 	docker.users[user]
 	lower(users[user]) == root_alias[alias]
 	msg = sprintf("%s: Please specify another USER, root (%s) is not permitted. More info: %s", [check02, user, l.get_url(check02)])

--- a/policy/docker/deny_using_root_alias_test.rego
+++ b/policy/docker/deny_using_root_alias_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_root_alias {
-	input := [
+test_deny_root_alias if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -27,11 +29,11 @@ test_deny_root_alias {
 		},
 	]
 
-	t.error_count(deny_root_alias, 1) with input as input
+	t.error_count(deny_root_alias, 1) with input as inp
 }
 
-test_not_deny_root_alias {
-	input := [
+test_not_deny_root_alias if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -55,5 +57,5 @@ test_not_deny_root_alias {
 		},
 	]
 
-	t.no_errors(deny_root_alias) with input as input
+	t.no_errors(deny_root_alias) with input as inp
 }

--- a/policy/docker/docker.rego
+++ b/policy/docker/docker.rego
@@ -1,46 +1,48 @@
 package docker
 
+import rego.v1
+
 import data.lib as l
 
-is_user {
+is_user if {
 	input[i].Cmd == "user"
 }
 
-command[cmd] {
+command contains cmd if {
 	cmd = input[i]
 }
 
-froms[from] {
+froms contains from if {
 	input[i].Cmd == "from"
 	from = input[i].Value[j]
 }
 
-runs[run] {
+runs contains run if {
 	input[i].Cmd == "run"
 	run = concat(" ", input[i].Value)
 }
 
-users[user] {
+users contains user if {
 	input[i].Cmd == "user"
 	user = input[i].Value[j]
 }
 
-adds[add] {
+adds contains add if {
 	input[i].Cmd == "add"
 	add = input[i].Value[j]
 }
 
-exposes[expose] {
+exposes contains expose if {
 	input[i].Cmd == "expose"
 	expose = input[i].Value[j]
 }
 
-labels[label_values] {
+labels contains label_values if {
 	input[i].Cmd == "label"
 	label_values = input[i].Value
 }
 
-make_exception(check) {
+make_exception(check) if {
 	labels[_][i] == "embark.dev/opa-docker"
 	exclusions := split(labels[_][_], ",")
 	l.contains_element(exclusions, check)

--- a/policy/docker/warn_latest_image.rego
+++ b/policy/docker/warn_latest_image.rego
@@ -1,22 +1,24 @@
 package docker
 
+import rego.v1
+
 import data.docker
 import data.lib as l
 
 check03 := "DOCKER_03"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check03)
 	rules = ["root_alias"]
 }
 
-image_tag_list = [
+image_tag_list := [
 	"latest",
 	"LATEST",
 ]
 
 # WARN(DOCKER_03): Using latest can result in unpredictive behavior
-warn_latest_tag[msg] {
+warn_latest_tag contains msg if {
 	docker.froms[from]
 	val := split(from, ":")
 	contains(val[1], image_tag_list[_])

--- a/policy/docker/warn_latest_image_test.rego
+++ b/policy/docker/warn_latest_image_test.rego
@@ -1,9 +1,11 @@
 package docker
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_latest_image {
-	input := [
+test_warn_latest_image if {
+	inp := [
 		{
 			"Cmd": "from",
 			"Flags": [],
@@ -27,5 +29,5 @@ test_warn_latest_image {
 		},
 	]
 
-	t.error_count(warn_latest_tag, 1) with input as input
+	t.error_count(warn_latest_tag, 1) with input as inp
 }

--- a/policy/kubernetes/deny_adding_capabilities_sysadmin.rego
+++ b/policy/kubernetes/deny_adding_capabilities_sysadmin.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -10,12 +12,12 @@ import data.lib as l
 #   https://kubesec.io/basics/containers-securitycontext-capabilities-add-index-sys-admin/
 checks05 := "K8S_05"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(checks05)
 	rules = ["adding_sysadmin_capabilities"]
 }
 
-deny_adding_sysadmin_capabilities[msg] {
+deny_adding_sysadmin_capabilities contains msg if {
 	kubernetes.containers[container]
 	kubernetes.added_capability(container, "CAP_SYS_ADMIN")
 	msg = sprintf("%s: %s in the %s %s has SYS_ADMIN capabilities. More info: %s", [checks05, container.name, kubernetes.kind, kubernetes.name, l.get_url(checks05)])

--- a/policy/kubernetes/deny_adding_capabilities_sysadmin_test.rego
+++ b/policy/kubernetes/deny_adding_capabilities_sysadmin_test.rego
@@ -1,81 +1,59 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_adding_capabilities_to_containers {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "capabilities": {
-                                    "add": ["CAP_SYS_ADMIN"]
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_adding_capabilities_to_containers if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_adding_sysadmin_capabilities, 1) with input as input
+	t.error_count(deny_adding_sysadmin_capabilities, 1) with input as inp
 }
 
-test_deny_adding_capabilities_to_init_containers {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "capabilities": {
-                                    "add": ["CAP_SYS_ADMIN"]
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_adding_capabilities_to_init_containers if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"capabilities": {"add": ["CAP_SYS_ADMIN"]}},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_adding_sysadmin_capabilities, 1) with input as input
+	t.error_count(deny_adding_sysadmin_capabilities, 1) with input as inp
 }

--- a/policy/kubernetes/deny_default_namespace.rego
+++ b/policy/kubernetes/deny_default_namespace.rego
@@ -1,27 +1,36 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
 # DENY(K8S_04): Using the default namespace leads to unpredictable behavior
-# Description: Resources in k8s should be segregated using namespaces. 
+# Description: Resources in k8s should be segregated using namespaces.
 #              Using the default namespace makes it more difficult to apply RBAC and similar controls
 # Links:
 #   CIS Controls 1.5.1, 5.7.4 (the default namespace should not be used)
 checks04 := "K8S_04"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(checks04)
 	rules = ["default_namespace"]
 }
 
-valid_namespace {
-	input.metadata.namespace
-	all([input.metadata.namespace != "default"])
+#valid_namespace if {
+#	not input.metadata.namespace
+#} else if {
+#	ns := input.metadata.namespace
+#	ns != "default"
+#}
+
+valid_namespace if {
+	ns := input.metadata.namespace
+	ns != "default"
 }
 
-deny_default_namespace[msg] {
-	not any([
+deny_default_namespace contains msg if {
+	not true in [
 		is_namespace,
 		is_clusterrole,
 		is_clusterrolebinding,
@@ -34,7 +43,7 @@ deny_default_namespace[msg] {
 		is_mutatingwebhookconfig,
 		is_podsecuritypolicy,
 		is_validatingwebhookconfig,
-	])
+	]
 
 	not valid_namespace
 	msg = sprintf("%s: the %s %s is using the default namespace. More info: %s", [checks04, kubernetes.kind, kubernetes.name, l.get_url(checks04)])

--- a/policy/kubernetes/deny_default_namespace_test.rego
+++ b/policy/kubernetes/deny_default_namespace_test.rego
@@ -1,50 +1,52 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_default_namespace {
-  input := {"kind": "Deployment", "metadata": { "name": "test", "namespace": "default" }}
+test_deny_default_namespace if {
+	inp := {"kind": "Deployment", "metadata": {"name": "test", "namespace": "default"}}
 
-  t.error_count(deny_default_namespace, 1) with input as input
+	t.error_count(deny_default_namespace, 1) with input as inp
 }
 
-test_deny_no_namespace {
-  input := {"kind": "Deployment", "metadata": { "name": "test" }}
+test_deny_no_namespace if {
+	inp := {"kind": "Deployment", "metadata": {"name": "test"}}
 
-  t.error_count(deny_default_namespace, 1) with input as input
+	t.error_count(deny_default_namespace, 1) with input as inp
 }
 
-test_allow_namespace {
-  input := {"kind": "Deployment", "metadata": { "name": "test", "namespace": "foobar" }}
+test_allow_namespace if {
+	inp := {"kind": "Deployment", "metadata": {"name": "test", "namespace": "foobar"}}
 
-  t.no_errors(deny_default_namespace) with input as input
+	t.no_errors(deny_default_namespace) with input as inp
 }
 
-test_allow_non_namespaced_kinds {
-  priorityClass := {"kind": "PriorityClass", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as priorityClass
+test_allow_non_namespaced_kinds if {
+	priorityClass := {"kind": "PriorityClass", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as priorityClass
 
-  persistentVolume := {"kind": "PersistentVolume", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as persistentVolume
+	persistentVolume := {"kind": "PersistentVolume", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as persistentVolume
 
-  apiservice := {"kind": "APIService", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as apiservice
+	apiservice := {"kind": "APIService", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as apiservice
 
-  crd := {"kind": "CustomResourceDefinition", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as crd
+	crd := {"kind": "CustomResourceDefinition", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as crd
 
-  storageclass := {"kind": "StorageClass", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as storageclass
+	storageclass := {"kind": "StorageClass", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as storageclass
 
-  csidriver := {"kind": "CSIDriver", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as csidriver
+	csidriver := {"kind": "CSIDriver", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as csidriver
 
-  mutatingwebhookconf := {"kind": "MutatingWebhookConfiguration", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as mutatingwebhookconf
+	mutatingwebhookconf := {"kind": "MutatingWebhookConfiguration", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as mutatingwebhookconf
 
-  podsecuritypolicy := {"kind": "PodSecurityPolicy", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as podsecuritypolicy
+	podsecuritypolicy := {"kind": "PodSecurityPolicy", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as podsecuritypolicy
 
-  validatingwebhookconfig := {"kind": "ValidatingWebhookConfiguration", "metadata": { "name": "test" }}
-  t.no_errors(deny_default_namespace) with input as validatingwebhookconfig
+	validatingwebhookconfig := {"kind": "ValidatingWebhookConfiguration", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as validatingwebhookconfig
 }

--- a/policy/kubernetes/deny_default_service_account.rego
+++ b/policy/kubernetes/deny_default_service_account.rego
@@ -1,28 +1,30 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
 # DENY(K8S_06): Don't allow usage of default service account
 # Description:
 # Links:
-# 
+#
 checks06 := "K8S_06"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(checks06)
 	rules = ["default_service_account"]
 }
 
-invalid_service_account(pod) {
+invalid_service_account(pod) if {
 	not pod.spec.serviceAccountName
-} else {
+} else if {
 	sa := pod.spec.serviceAccountName
 	sa == "default"
 }
 
-deny_default_service_account[msg] {
+deny_default_service_account contains msg if {
 	kubernetes.pods[pod]
-	any([invalid_service_account(pod)])
+	true in [invalid_service_account(pod)]
 	msg = sprintf("%s: the %s %s is using a default service account. More info: %s", [checks06, kubernetes.kind, kubernetes.name, l.get_url(checks06)])
 }

--- a/policy/kubernetes/deny_default_service_account_test.rego
+++ b/policy/kubernetes/deny_default_service_account_test.rego
@@ -1,86 +1,68 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_no_service_account_name {
-    input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                }
-            }
-        }
-    }
+test_deny_no_service_account_name if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {"securityContext": {"runAsNonRoot": true}}},
+		},
+	}
 
-  t.error_count(deny_default_service_account, 1) with input as input
+	t.error_count(deny_default_service_account, 1) with input as inp
 }
 
-test_deny_default_service_account_name {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "default",
-                }
-            }
-        }
-    }
+test_deny_default_service_account_name if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "default",
+			}},
+		},
+	}
 
-  t.error_count(deny_default_service_account, 1) with input as input
+	t.error_count(deny_default_service_account, 1) with input as inp
 }
 
-test_allow_valid_service_account_name {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "notDefault",
-                }
-            }
-        }
-    }
+test_allow_valid_service_account_name if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "notDefault",
+			}},
+		},
+	}
 
-  t.no_errors(deny_default_service_account) with input as input
+	t.no_errors(deny_default_service_account) with input as inp
 }

--- a/policy/kubernetes/deny_deprecated_service_account.rego
+++ b/policy/kubernetes/deny_deprecated_service_account.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -8,12 +10,12 @@ import data.lib as l
 # serviceAccount is deprecated and serviceAccountName should be used instead
 checks07 := "K8S_07"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(checks07)
 	rules = ["deprecated_service_account"]
 }
 
-deny_deprecated_service_account[msg] {
+deny_deprecated_service_account contains msg if {
 	kubernetes.pods[pod]
 	pod.spec.serviceAccount
 	msg = sprintf("%s: the %s %s is using the deprecated serviceaccount, use serviceAccountName", [checks07, kubernetes.kind, kubernetes.name, l.get_url(checks07)])

--- a/policy/kubernetes/deny_deprecated_service_account_test.rego
+++ b/policy/kubernetes/deny_deprecated_service_account_test.rego
@@ -1,31 +1,27 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_deprecated_service_account {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-        "name": "sample",
-        "namespace":"test",
-    },
-    "spec": {
-        "selector": {
-            "matchLabels": {
-                "app": "app",
-                "release": "release"
-            }
-        },
-        "template": {
-            "spec": {
-                "securityContext": {
-                    "runAsNonRoot": true,
-                },
-                "serviceAccount":"sample",
-            }
-        }
-    }
-}
+test_deny_deprecated_service_account if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccount": "sample",
+			}},
+		},
+	}
 
-  t.error_count(deny_deprecated_service_account, 1) with input as input
+	t.error_count(deny_deprecated_service_account, 1) with input as inp
 }

--- a/policy/kubernetes/deny_latest_tag.rego
+++ b/policy/kubernetes/deny_latest_tag.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check03 := "K8S_03"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check03)
 	rules = ["usage_of_latest_tag"]
 }
 
-deny_usage_of_latest_tag[msg] {
+deny_usage_of_latest_tag contains msg if {
 	kubernetes.containers[container]
 	[image_name, "latest"] = kubernetes.split_image(container.image)
 	msg = sprintf("%s: %s in the %s %s has an image, %s, using the latest tag. More info: %s", [check03, container.name, kubernetes.kind, image_name, kubernetes.name, l.get_url(check03)])

--- a/policy/kubernetes/deny_latest_tag_test.rego
+++ b/policy/kubernetes/deny_latest_tag_test.rego
@@ -1,32 +1,24 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_deployment_with_latest {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-          "containers": [
-              {
-                  "name": "test",
-                  "image":"org/image:latest"
-              }
-          ]
-        }
-      }
-    }
-  }
+test_deny_deployment_with_latest if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {"containers": [{
+				"name": "test",
+				"image": "org/image:latest",
+			}]}},
+		},
+	}
 
-  t.error_count(deny_usage_of_latest_tag, 1) with input as input
+	t.error_count(deny_usage_of_latest_tag, 1) with input as inp
 }

--- a/policy/kubernetes/deny_managing_host_alias.rego
+++ b/policy/kubernetes/deny_managing_host_alias.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/spec-hostaliases/
 check15 := "K8S_15"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check15)
 	rules = ["managing_host_alias"]
 }
 
-deny_managing_host_alias[msg] {
+deny_managing_host_alias contains msg if {
 	kubernetes.pods[pod]
 	pod.spec.hostAliases
 	msg = sprintf("%s: The %s %s is managing host aliases. More info: %s", [check15, kubernetes.kind, kubernetes.name, l.get_url(check15)])

--- a/policy/kubernetes/deny_managing_host_alias_test.rego
+++ b/policy/kubernetes/deny_managing_host_alias_test.rego
@@ -1,39 +1,27 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_managing_host_alias {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-			"hostAliases": [
-				{
+test_deny_managing_host_alias if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"hostAliases": [{
 					"ip": "127.0.0.1",
-					"hostnames": [
-						"abc"
-					]
-				}
-			],
-			"containers": [
-				{
-					"image":"org/image:lol"
-				}
-			]
-        }
-      }
-    }
-  }
+					"hostnames": ["abc"],
+				}],
+				"containers": [{"image": "org/image:lol"}],
+			}},
+		},
+	}
 
-  t.error_count(deny_managing_host_alias, 1) with input as input
+	t.error_count(deny_managing_host_alias, 1) with input as inp
 }

--- a/policy/kubernetes/deny_mount_docker_socket.rego
+++ b/policy/kubernetes/deny_mount_docker_socket.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check10 := "K8S_10"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check10)
 	rules = ["mounting_docker_socket"]
 }
 
-deny_mounting_docker_socket[msg] {
+deny_mounting_docker_socket contains msg if {
 	kubernetes.volumes[volume]
 	volume.hostPath.path = "/var/run/docker.sock"
 	msg = sprintf("%s: The %s %s is mounting the Docker socket. More info: %s", [check10, kubernetes.kind, kubernetes.name, l.get_url(check10)])

--- a/policy/kubernetes/deny_mount_docker_socket_test.rego
+++ b/policy/kubernetes/deny_mount_docker_socket_test.rego
@@ -1,135 +1,87 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_socket_mount_pod {
-  input := {
-    "kind": "Pod",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "containers": [
-        {
-            "image":"org/image:latest"
-        }
-      ],
-      "volumes": [
-        {
-          "name":"something",
-          "hostPath": {
-            "path": "/var/run/docker.sock"
-          }
-        }
-      ]
-    }
-  }
+test_deny_socket_mount_pod if {
+	inp := {
+		"kind": "Pod",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"containers": [{"image": "org/image:latest"}],
+			"volumes": [{
+				"name": "something",
+				"hostPath": {"path": "/var/run/docker.sock"},
+			}],
+		},
+	}
 
-  t.error_count(deny_mounting_docker_socket, 1) with input as input
+	t.error_count(deny_mounting_docker_socket, 1) with input as inp
 }
 
-test_allow_socket_mount_pod {
-  input := {
-    "kind": "Pod",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "containers": [
-        {
-            "image":"org/image:latest"
-        }
-      ],
-      "volumes": [
-        {
-          "name":"something",
-          "hostPath": {
-            "path": "something_else"
-          }
-        }
-      ]
-    }
-  }
+test_allow_socket_mount_pod if {
+	inp := {
+		"kind": "Pod",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"containers": [{"image": "org/image:latest"}],
+			"volumes": [{
+				"name": "something",
+				"hostPath": {"path": "something_else"},
+			}],
+		},
+	}
 
-  t.no_errors(deny_mounting_docker_socket) with input as input
+	t.no_errors(deny_mounting_docker_socket) with input as inp
 }
 
-test_deny_socket_mount_deployment {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-          "containers": [
-              {
-                  "image":"org/image:latest"
-              }
-          ],
-          "volumes": [
-            {
-              "name":"something",
-              "hostPath": {
-                "path": "/var/run/docker.sock"
-              }
-            }
-          ]
-        }
-      }
-    }
-  }
+test_deny_socket_mount_deployment if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"containers": [{"image": "org/image:latest"}],
+				"volumes": [{
+					"name": "something",
+					"hostPath": {"path": "/var/run/docker.sock"},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_mounting_docker_socket, 1) with input as input
+	t.error_count(deny_mounting_docker_socket, 1) with input as inp
 }
 
-test_deny_socket_mount_job {
-  input := {
-    "apiVersion": "batch/v1beta1",
-    "kind": "CronJob",
-    "metadata": {
-      "name": "hello"
-    },
-    "spec": {
-      "schedule": "*/1 * * * *",
-      "jobTemplate": {
-        "spec": {
-          "template": {
-            "spec": {
-              "containers": [],
-              "volumes": [
-                {
-                  "name":"something",
-                  "hostPath": {
-                    "path": "/var/run/docker.sock"
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-    }
-  }
+test_deny_socket_mount_job if {
+	inp := {
+		"apiVersion": "batch/v1beta1",
+		"kind": "CronJob",
+		"metadata": {"name": "hello"},
+		"spec": {
+			"schedule": "*/1 * * * *",
+			"jobTemplate": {"spec": {"template": {"spec": {
+				"containers": [],
+				"volumes": [{
+					"name": "something",
+					"hostPath": {"path": "/var/run/docker.sock"},
+				}],
+			}}}},
+		},
+	}
 
-  t.error_count(deny_mounting_docker_socket, 1) with input as input
+	t.error_count(deny_mounting_docker_socket, 1) with input as inp
 }

--- a/policy/kubernetes/deny_non_read_only_root_fs.rego
+++ b/policy/kubernetes/deny_non_read_only_root_fs.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/containers-securitycontext-readonlyrootfilesystem-true
 check14 := "K8S_14"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check14)
 	rules = ["non_read_only_root_fs"]
 }
 
-deny_non_read_only_root_fs[msg] {
+deny_non_read_only_root_fs contains msg if {
 	kubernetes.containers[container]
 	not container.securityContext.readOnlyRootFilesystem = true
 	msg = sprintf("%s: %s in the %s %s is not using a read only root filesystem. More info: %s", [check14, container.name, kubernetes.kind, kubernetes.name, l.get_url(check14)])

--- a/policy/kubernetes/deny_non_read_only_root_fs_test.rego
+++ b/policy/kubernetes/deny_non_read_only_root_fs_test.rego
@@ -1,74 +1,58 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_non_read_only_root_fs {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_non_read_only_root_fs if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_non_read_only_root_fs, 1) with input as input
+	t.error_count(deny_non_read_only_root_fs, 1) with input as inp
 }
 
-test_deny_non_read_only_root_fs {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "readOnlyRootFilesystem": "true"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_non_read_only_root_fs if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"readOnlyRootFilesystem": "true"},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_non_read_only_root_fs, 1) with input as input
+	t.error_count(deny_non_read_only_root_fs, 1) with input as inp
 }

--- a/policy/kubernetes/deny_privilege_escalation.rego
+++ b/policy/kubernetes/deny_privilege_escalation.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/containers-securitycontext-privileged-true/
 check01 := "K8S_01"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check01)
 	rules = ["privilege_escalation_in_containers"]
 }
 
-deny_privilege_escalation_in_containers[msg] {
+deny_privilege_escalation_in_containers contains msg if {
 	kubernetes.containers[container]
 	container.securityContext.allowPrivilegeEscalation
 	msg = sprintf("%s: %s in the %s %s is privileged. More info: %s", [check01, container.name, kubernetes.kind, kubernetes.name, l.get_url(check01)])

--- a/policy/kubernetes/deny_privilege_escalation_test.rego
+++ b/policy/kubernetes/deny_privilege_escalation_test.rego
@@ -1,77 +1,59 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_container_privilege_escalation {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "allowPrivilegeEscalation": true,
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_container_privilege_escalation if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"allowPrivilegeEscalation": true},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_privilege_escalation_in_containers, 1) with input as input
+	t.error_count(deny_privilege_escalation_in_containers, 1) with input as inp
 }
 
-test_deny_init_container_privilege_escalation {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "allowPrivilegeEscalation": "true",
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_init_container_privilege_escalation if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"allowPrivilegeEscalation": "true"},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_privilege_escalation_in_containers, 1) with input as input
+	t.error_count(deny_privilege_escalation_in_containers, 1) with input as inp
 }

--- a/policy/kubernetes/deny_run_as_root.rego
+++ b/policy/kubernetes/deny_run_as_root.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,19 +11,19 @@ import data.lib as l
 #   https://kubesec.io/basics/containers-securitycontext-runasnonroot-true/
 check02 := "K8S_02"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check02)
 	rules = ["run_container_as_root"]
 }
 
-podOrContainerRunningAsRoot(pod) {
+podOrContainerRunningAsRoot(pod) if {
 	not pod.spec.securityContext.runAsNonRoot
 	containers := kubernetes.pod_containers(pod)
 	container := containers[_]
 	not container.securityContext.runAsNonRoot
 }
 
-deny_run_container_as_root[msg] {
+deny_run_container_as_root contains msg if {
 	kubernetes.pods[pod]
 	podOrContainerRunningAsRoot(pod)
 	msg = sprintf("%s: %s %s is running as root. More info: %s", [check02, kubernetes.kind, kubernetes.name, l.get_url(check02)])

--- a/policy/kubernetes/deny_run_as_root_test.rego
+++ b/policy/kubernetes/deny_run_as_root_test.rego
@@ -1,136 +1,110 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_deployment_without_security_context {
-  input := {
-      "kind": "Deployment",
-      "metadata": {
-          "name": "sample",
-          "namespace":"test",
-      },
-      "spec": {
-          "selector": {
-              "matchLabels": {
-                  "app": "app",
-                  "release": "release"
-              }
-          },
-          "template": {
-              "spec": {
-                  "serviceAccountName": "sample",
-                  "containers": [
-                      {
-                          "name": "test",
-                          "image": "test",
-                      }
-                  ]
-              }
-          }
-      }
-  }
-  t.error_count(deny_run_container_as_root, 1) with input as input
+test_deny_deployment_without_security_context if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"serviceAccountName": "sample",
+				"containers": [{
+					"name": "test",
+					"image": "test",
+				}],
+			}},
+		},
+	}
+	t.error_count(deny_run_container_as_root, 1) with input as inp
 }
 
-test_allow_deployment_with_pod_security_context {
-  input := {
-      "kind": "Deployment",
-      "metadata": {
-          "name": "sample",
-          "namespace":"test",
-      },
-      "spec": {
-          "selector": {
-              "matchLabels": {
-                  "app": "app",
-                  "release": "release"
-              }
-          },
-          "template": {
-              "spec": {
-                  "serviceAccountName": "sample",
-                  "securityContext": {
-                      "runAsNonRoot": true,
-                  },
-                  "containers": [
-                      {
-                          "name": "test",
-                          "image": "test",
-                      }
-                  ]
-              }
-          }
-      }
-  }
-  t.no_errors(deny_run_container_as_root) with input as input
+test_allow_deployment_with_pod_security_context if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"serviceAccountName": "sample",
+				"securityContext": {"runAsNonRoot": true},
+				"containers": [{
+					"name": "test",
+					"image": "test",
+				}],
+			}},
+		},
+	}
+	t.no_errors(deny_run_container_as_root) with input as inp
 }
 
-test_allow_deployment_with_container_security_context {
-  input := {
-      "kind": "Deployment",
-      "metadata": {
-          "name": "sample",
-          "namespace":"test",
-      },
-      "spec": {
-          "selector": {
-              "matchLabels": {
-                  "app": "app",
-                  "release": "release"
-              }
-          },
-          "template": {
-              "spec": {
-                  "serviceAccountName": "sample",
-                  "containers": [
-                      {
-                          "name": "test",
-                          "image": "test",
-                          "securityContext": {
-                              "runAsNonRoot": true,
-                          },
-                      }
-                  ]
-              }
-          }
-      }
-  }
-  t.no_errors(deny_run_container_as_root) with input as input
+test_allow_deployment_with_container_security_context if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"serviceAccountName": "sample",
+				"containers": [{
+					"name": "test",
+					"image": "test",
+					"securityContext": {"runAsNonRoot": true},
+				}],
+			}},
+		},
+	}
+	t.no_errors(deny_run_container_as_root) with input as inp
 }
 
-test_deny_deployment_with_partial_container_security_context {
-  input := {
-      "kind": "Deployment",
-      "metadata": {
-          "name": "sample",
-          "namespace":"test",
-      },
-      "spec": {
-          "selector": {
-              "matchLabels": {
-                  "app": "app",
-                  "release": "release"
-              }
-          },
-          "template": {
-              "spec": {
-                  "serviceAccountName": "sample",
-                  "containers": [
-                      {
-                          "name": "test",
-                          "image": "test",
-                          "securityContext": {
-                              "runAsNonRoot": true,
-                          },
-                      },
-                      {
-                          "name": "test",
-                          "image": "test",
-                      }
-                  ]
-              }
-          }
-      }
-  }
-  t.error_count(deny_run_container_as_root, 1) with input as input
+test_deny_deployment_with_partial_container_security_context if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"serviceAccountName": "sample",
+				"containers": [
+					{
+						"name": "test",
+						"image": "test",
+						"securityContext": {"runAsNonRoot": true},
+					},
+					{
+						"name": "test",
+						"image": "test",
+					},
+				],
+			}},
+		},
+	}
+	t.error_count(deny_run_container_as_root, 1) with input as inp
 }

--- a/policy/kubernetes/deny_run_as_user_too_low.rego
+++ b/policy/kubernetes/deny_run_as_user_too_low.rego
@@ -1,20 +1,22 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
-# DENY(K8S_19): 
-# Description: 
+# DENY(K8S_19):
+# Description:
 # Links:
 #   https://kubesec.io/basics/containers-securitycontext-runasuser/
 check19 := "K8S_19"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check19)
 	rules = ["run_as_user_too_low"]
 }
 
-deny_run_as_user_too_low[msg] {
+deny_run_as_user_too_low contains msg if {
 	kubernetes.containers[container]
 	to_number(container.securityContext.runAsUser) < 10000
 	msg = sprintf("%s: %s in the %s %s has a UID of less than 10000. More info: %s", [check19, container.name, kubernetes.kind, kubernetes.name, l.get_url(check19)])

--- a/policy/kubernetes/deny_run_as_user_too_low_test.rego
+++ b/policy/kubernetes/deny_run_as_user_too_low_test.rego
@@ -1,76 +1,60 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_run_as_user_too_low {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                            "securityContext": {
-                                "runAsUser": "3"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_deny_run_as_user_too_low if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"securityContext": {"runAsUser": "3"},
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_run_as_user_too_low, 1) with input as input
+	t.error_count(deny_run_as_user_too_low, 1) with input as inp
 }
 
 # We've decided to allow having this undefined and rely on
 # the runAsNonRoot policy check
-test_allow_run_as_user_undefined {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name": "test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_allow_run_as_user_undefined if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-  t.no_errors(deny_run_as_user_too_low) with input as input
+	t.no_errors(deny_run_as_user_too_low) with input as inp
 }

--- a/policy/kubernetes/deny_share_host_ipc.rego
+++ b/policy/kubernetes/deny_share_host_ipc.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/spec-hostipc/
 check16 := "K8S_16"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check16)
 	rules = ["sharing_host_ipc"]
 }
 
-deny_sharing_host_ipc[msg] {
+deny_sharing_host_ipc contains msg if {
 	kubernetes.pods[pod]
 	pod.spec.hostIPC
 	msg = sprintf("%s: %s %s is sharing the host IPC namespace. More info: %s", [check16, kubernetes.kind, kubernetes.name, l.get_url(check16)])

--- a/policy/kubernetes/deny_share_host_ipc_test.rego
+++ b/policy/kubernetes/deny_share_host_ipc_test.rego
@@ -1,33 +1,27 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_sharing_host_ipc {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-          "hostIPC": "true",
-          "containers": [
-            {
-              "name": "test",
-              "image":"org/image:lol"
-            }
-          ]
-        }
-      }
-    }
-  }
+test_deny_sharing_host_ipc if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"hostIPC": "true",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:lol",
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_sharing_host_ipc, 1) with input as input
+	t.error_count(deny_sharing_host_ipc, 1) with input as inp
 }

--- a/policy/kubernetes/deny_share_host_network.rego
+++ b/policy/kubernetes/deny_share_host_network.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/spec-hostnetwork/
 check18 := "K8S_18"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check18)
 	rules = ["sharing_host_network"]
 }
 
-deny_sharing_host_network[msg] {
+deny_sharing_host_network contains msg if {
 	kubernetes.pods[pod]
 	pod.spec.hostNetwork
 	msg = sprintf("%s: The %s %s is connected to the host network. More info %s", [check18, kubernetes.kind, kubernetes.name, l.get_url(check18)])

--- a/policy/kubernetes/deny_share_host_network_test.rego
+++ b/policy/kubernetes/deny_share_host_network_test.rego
@@ -1,32 +1,24 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_sharing_host_network {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-          "hostNetwork": true,
-          "containers": [
-            {
-              "image":"org/image:lol"
-            }
-          ]
-        }
-      }
-    }
-  }
+test_deny_sharing_host_network if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"hostNetwork": true,
+				"containers": [{"image": "org/image:lol"}],
+			}},
+		},
+	}
 
-  t.error_count(deny_sharing_host_network, 1) with input as input
+	t.error_count(deny_sharing_host_network, 1) with input as inp
 }

--- a/policy/kubernetes/deny_share_host_pid.rego
+++ b/policy/kubernetes/deny_share_host_pid.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #   https://kubesec.io/basics/spec-hostpid/
 check17 := "K8S_17"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check17)
 	rules = ["sharing_host_pid"]
 }
 
-deny_sharing_host_pid[msg] {
+deny_sharing_host_pid contains msg if {
 	kubernetes.pods[pod]
 	pod.spec.hostPID
 	msg = sprintf("%s: The %s %s is sharing the host PID. More info: %s", [check17, kubernetes.kind, kubernetes.name, l.get_url(check17)])

--- a/policy/kubernetes/deny_share_host_pid_test.rego
+++ b/policy/kubernetes/deny_share_host_pid_test.rego
@@ -1,33 +1,27 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_sharing_host_pid {
-  input := {
-    "kind": "Deployment",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "template": {
-        "spec": {
-          "hostPID": true,
-          "containers": [
-            {
-              "name":"test",
-              "image":"org/image:lol"
-            }
-          ]
-        }
-      }
-    }
-  }
+test_deny_sharing_host_pid if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"hostPID": true,
+				"containers": [{
+					"name": "test",
+					"image": "org/image:lol",
+				}],
+			}},
+		},
+	}
 
-  t.error_count(deny_sharing_host_pid, 1) with input as input
+	t.error_count(deny_sharing_host_pid, 1) with input as inp
 }

--- a/policy/kubernetes/kubernetes.rego
+++ b/policy/kubernetes/kubernetes.rego
@@ -1,101 +1,107 @@
 package kubernetes
 
+import rego.v1
+
 import data.lib as l
 
-name = input.metadata.name
+name := input.metadata.name
 
-namespace = input.metadata.namespace
+namespace := input.metadata.namespace
 
-kind = input.kind
+kind := input.kind
 
-is_service = kind == "Service"
+is_service := kind == "Service"
 
-is_workload = any([
-	kind == "DaemonSet",
-	kind == "Deployment",
-	kind == "GameServer",
-	kind == "StatefulSet",
-	kind == "ReplicaSet",
-	kind == "ReplicationController",
-])
+is_workload if {
+	true in [
+		kind == "DaemonSet",
+		kind == "Deployment",
+		kind == "GameServer",
+		kind == "StatefulSet",
+		kind == "ReplicaSet",
+		kind == "ReplicationController",
+	]
+}
 
-is_pod = kind == "Pod"
+is_pod := kind == "Pod"
 
-is_namespace = kind == "Namespace"
+is_namespace := kind == "Namespace"
 
-is_clusterrole = kind == "ClusterRole"
+is_clusterrole := kind == "ClusterRole"
 
-is_clusterrolebinding = kind == "ClusterRoleBinding"
+is_clusterrolebinding := kind == "ClusterRoleBinding"
 
-is_priorityclass = kind == "PriorityClass"
+is_priorityclass := kind == "PriorityClass"
 
-is_persistentvolume = kind == "PersistentVolume"
+is_persistentvolume := kind == "PersistentVolume"
 
-is_apiservice = kind == "APIService"
+is_apiservice := kind == "APIService"
 
-is_customresourcedefinition = kind == "CustomResourceDefinition"
+is_customresourcedefinition := kind == "CustomResourceDefinition"
 
-is_storageclass = kind == "StorageClass"
+is_storageclass := kind == "StorageClass"
 
-is_csidriver = kind == "CSIDriver"
+is_csidriver := kind == "CSIDriver"
 
-is_podsecuritypolicy = kind == "PodSecurityPolicy"
+is_podsecuritypolicy := kind == "PodSecurityPolicy"
 
-is_mutatingwebhookconfig = kind == "MutatingWebhookConfiguration"
+is_mutatingwebhookconfig := kind == "MutatingWebhookConfiguration"
 
-is_validatingwebhookconfig = kind == "ValidatingWebhookConfiguration"
+is_validatingwebhookconfig := kind == "ValidatingWebhookConfiguration"
 
-is_job = any([kind == "CronJob", kind == "Job"])
+is_job if {
+	true in [kind == "CronJob", kind == "Job"]
+}
 
-split_image(image) = [image_name, lower(tag)] {
+split_image(image) := [image_name, lower(tag)] if {
 	[image_name, tag] = split(image, ":")
 }
 
-pod_containers(pod) = all_containers {
+pod_containers(pod) := all_containers if {
 	keys = {"containers", "initContainers"}
 	all_containers = [c | keys[k]; c = pod.spec[k][_]]
 }
 
-containers[container] {
+containers contains container if {
 	pods[pod]
 	all_containers = pod_containers(pod)
 	container = all_containers[_]
 }
 
-containers[container] {
+containers contains container if {
 	all_containers = pod_containers(input)
 	container = all_containers[_]
 }
 
-pods[pod] {
+pods contains pod if {
 	is_workload
 	pod = input.spec.template
 }
 
-pods[pod] {
+pods contains pod if {
 	is_pod
 	pod = input
 }
 
-pods[pod] {
+pods contains pod if {
 	is_job
 	pod = input.spec.jobTemplate.spec.template
 }
 
-volumes[volume] {
+volumes contains volume if {
 	pods[pod]
 	volume = pod.spec.volumes[_]
 }
 
-dropped_capability(container, cap) {
+dropped_capability(container, cap) if {
 	container.securityContext.capabilities.drop[_] == cap
 }
 
-added_capability(container, cap) {
+added_capability(container, cap) if {
 	container.securityContext.capabilities.add[_] == cap
 }
 
-make_exception(check) {
+make_exception(check) if {
 	input.metadata.annotations["embark.dev/opa-k8s"]
 	checks := split(input.metadata.annotations["embark.dev/opa-k8s"], ",")
 	l.contains_element(checks, check)

--- a/policy/kubernetes/warn_cpu_requests.rego
+++ b/policy/kubernetes/warn_cpu_requests.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check09 := "K8S_09"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check09)
 	rules = ["cpu_requests"]
 }
 
-warn_cpu_requests[msg] {
+warn_cpu_requests contains msg if {
 	kubernetes.containers[container]
 	not container.resources.requests.cpu
 	msg = sprintf("%s: %s in the %s %s does not have a cpu request set. More info: %s", [check09, container.name, kubernetes.kind, kubernetes.name, l.get_url(check09)])

--- a/policy/kubernetes/warn_cpu_requests_test.rego
+++ b/policy/kubernetes/warn_cpu_requests_test.rego
@@ -1,71 +1,57 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_cpu_requests_in_containers {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_cpu_requests_in_containers if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-  t.error_count(warn_cpu_requests, 1) with input as input
+	t.error_count(warn_cpu_requests, 1) with input as inp
 }
 
-test_warn_cpu_requests_in_init_containers {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_cpu_requests_in_init_containers if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-  t.error_count(warn_cpu_requests, 1) with input as input
+	t.error_count(warn_cpu_requests, 1) with input as inp
 }

--- a/policy/kubernetes/warn_liveness_probe.rego
+++ b/policy/kubernetes/warn_liveness_probe.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check20 := "K8S_20"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check20)
 	rules = ["liveness_probes"]
 }
 
-warn_liveness_probes[msg] {
+warn_liveness_probes contains msg if {
 	is_workload
 	kubernetes.containers[container]
 	not container.livenessProbe

--- a/policy/kubernetes/warn_liveness_probe_test.rego
+++ b/policy/kubernetes/warn_liveness_probe_test.rego
@@ -1,117 +1,89 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_liveness_probes {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_liveness_probes if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_liveness_probes, 1) with input as input
+	t.error_count(warn_liveness_probes, 1) with input as inp
 }
 
-test_warn_liveness_probes_init_container {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_liveness_probes_init_container if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_liveness_probes, 1) with input as input
+	t.error_count(warn_liveness_probes, 1) with input as inp
 }
 
-test_not_warn_liveness_probes {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                            "resources": {
-                                "limits": {
-                                    "memory":"500m"
-                                }
-                            },
-                            "livenessProbe": {
-                                "exec": {
-                                    "command": ["cat", "/tmp/healthy"]
-                                },
-                                "initialDelaySeconds": 5,
-                                "periodSeconds": 5
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_not_warn_liveness_probes if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"resources": {"limits": {"memory": "500m"}},
+					"livenessProbe": {
+						"exec": {"command": ["cat", "/tmp/healthy"]},
+						"initialDelaySeconds": 5,
+						"periodSeconds": 5,
+					},
+				}],
+			}},
+		},
+	}
 
-    t.no_errors(warn_liveness_probes) with input as input
+	t.no_errors(warn_liveness_probes) with input as inp
 }

--- a/policy/kubernetes/warn_memory_limits.rego
+++ b/policy/kubernetes/warn_memory_limits.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check12 := "K8S_12"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check12)
 	rules = ["memory_limits"]
 }
 
-warn_memory_limits[msg] {
+warn_memory_limits contains msg if {
 	kubernetes.containers[container]
 	not container.resources.limits.memory
 	msg = sprintf("%s: %s in the %s %s does not have a memory limit set. More info: %s", [check12, container.name, kubernetes.kind, kubernetes.name, l.get_url(check12)])

--- a/policy/kubernetes/warn_memory_limits_test.rego
+++ b/policy/kubernetes/warn_memory_limits_test.rego
@@ -1,110 +1,84 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_memory_limits_on_container {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_memory_limits_on_container if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_memory_limits, 1) with input as input
+	t.error_count(warn_memory_limits, 1) with input as inp
 }
 
-test_warn_memory_limits_init_container {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_memory_limits_init_container if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_memory_limits, 1) with input as input
+	t.error_count(warn_memory_limits, 1) with input as inp
 }
 
-test_not_warn_memory_limits {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                            "resources": {
-                                "limits": {
-                                    "memory":"500m"
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_not_warn_memory_limits if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"resources": {"limits": {"memory": "500m"}},
+				}],
+			}},
+		},
+	}
 
-    t.no_errors(warn_memory_limits) with input as input
+	t.no_errors(warn_memory_limits) with input as inp
 }

--- a/policy/kubernetes/warn_memory_requests.rego
+++ b/policy/kubernetes/warn_memory_requests.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check13 := "K8S_13"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check13)
 	rules = ["memory_requests"]
 }
 
-warn_memory_requests[msg] {
+warn_memory_requests contains msg if {
 	kubernetes.containers[container]
 	not container.resources.requests.memory
 	msg = sprintf("%s: %s in the %s %s does not have a memory requests set. More info: %s", [check13, container.name, kubernetes.kind, kubernetes.name, l.get_url(check13)])

--- a/policy/kubernetes/warn_memory_requests_test.rego
+++ b/policy/kubernetes/warn_memory_requests_test.rego
@@ -1,76 +1,58 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_memory_requests {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_memory_requests if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_memory_requests, 1) with input as input
+	t.error_count(warn_memory_requests, 1) with input as inp
 }
 
-test_not_warn_memory_requests {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                            "resources": {
-                                "requests": {
-                                    "memory":"64Mi"
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_not_warn_memory_requests if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"resources": {"requests": {"memory": "64Mi"}},
+				}],
+			}},
+		},
+	}
 
-    t.no_errors(warn_memory_requests) with input as input
+	t.no_errors(warn_memory_requests) with input as inp
 }

--- a/policy/kubernetes/warn_readiness_probe.rego
+++ b/policy/kubernetes/warn_readiness_probe.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -9,12 +11,12 @@ import data.lib as l
 #
 check21 := "K8S_21"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check21)
 	rules = ["readiness_probes"]
 }
 
-warn_readiness_probes[msg] {
+warn_readiness_probes contains msg if {
 	is_workload
 	kubernetes.containers[container]
 	not container.readinessProbe

--- a/policy/kubernetes/warn_readiness_probe_test.rego
+++ b/policy/kubernetes/warn_readiness_probe_test.rego
@@ -1,117 +1,89 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_readiness_probes {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_readiness_probes if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_readiness_probes, 1) with input as input
+	t.error_count(warn_readiness_probes, 1) with input as inp
 }
 
-test_warn_readiness_probes_init_container {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "initContainers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_warn_readiness_probes_init_container if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"initContainers": [{
+					"name": "test",
+					"image": "org/image:latest",
+				}],
+			}},
+		},
+	}
 
-    t.error_count(warn_readiness_probes, 1) with input as input
+	t.error_count(warn_readiness_probes, 1) with input as inp
 }
 
-test_not_warn_readiness_probes {
-  input := {
-        "kind": "Deployment",
-        "metadata": {
-            "name": "sample",
-            "namespace":"test",
-        },
-        "spec": {
-            "selector": {
-                "matchLabels": {
-                    "app": "app",
-                    "release": "release"
-                }
-            },
-            "template": {
-                "spec": {
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                    },
-                    "serviceAccountName": "test",
-                    "containers": [
-                        {
-                            "name":"test",
-                            "image":"org/image:latest",
-                            "resources": {
-                                "limits": {
-                                    "memory":"500m"
-                                }
-                            },
-                            "readinessProbe": {
-                                "exec": {
-                                    "command": ["cat", "/tmp/healthy"]
-                                },
-                                "initialDelaySeconds": 5,
-                                "periodSeconds": 5
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    }
+test_not_warn_readiness_probes if {
+	inp := {
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample",
+			"namespace": "test",
+		},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"template": {"spec": {
+				"securityContext": {"runAsNonRoot": true},
+				"serviceAccountName": "test",
+				"containers": [{
+					"name": "test",
+					"image": "org/image:latest",
+					"resources": {"limits": {"memory": "500m"}},
+					"readinessProbe": {
+						"exec": {"command": ["cat", "/tmp/healthy"]},
+						"initialDelaySeconds": 5,
+						"periodSeconds": 5,
+					},
+				}],
+			}},
+		},
+	}
 
-    t.no_errors(warn_readiness_probes) with input as input
+	t.no_errors(warn_readiness_probes) with input as inp
 }

--- a/policy/kubernetes/warn_specify_host_port.rego
+++ b/policy/kubernetes/warn_specify_host_port.rego
@@ -1,5 +1,7 @@
 package kubernetes
 
+import rego.v1
+
 import data.kubernetes
 import data.lib as l
 
@@ -12,12 +14,12 @@ import data.lib as l
 #
 check11 := "K8S_11"
 
-exception[rules] {
+exception contains rules if {
 	make_exception(check11)
 	rules = ["specify_host_port"]
 }
 
-warn_specify_host_port[msg] {
+warn_specify_host_port contains msg if {
 	kubernetes.containers[container]
 	container.ports[port].hostPort
 

--- a/policy/kubernetes/warn_specify_host_port_test.rego
+++ b/policy/kubernetes/warn_specify_host_port_test.rego
@@ -1,34 +1,28 @@
 package kubernetes
 
+import rego.v1
+
 import data.testing as t
 
-test_warn_specify_host_port {
-  input := {
-    "kind": "Pod",
-    "metadata": {
-      "name": "sample",
-    },
-    "spec": {
-      "selector": {
-        "matchLabels": {
-          "app": "app",
-          "release": "release"
-        }
-      },
-      "containers": [
-        {
-            "name": "container",
-            "image":"org/image:latest",
-            "ports": [
-              {
-                "containerPort":"8080",
-                "hostPort":"1337"
-              }
-            ]
-        }
-      ],
-    }
-  }
+test_warn_specify_host_port if {
+	inp := {
+		"kind": "Pod",
+		"metadata": {"name": "sample"},
+		"spec": {
+			"selector": {"matchLabels": {
+				"app": "app",
+				"release": "release",
+			}},
+			"containers": [{
+				"name": "container",
+				"image": "org/image:latest",
+				"ports": [{
+					"containerPort": "8080",
+					"hostPort": "1337",
+				}],
+			}],
+		},
+	}
 
-  t.error_count(warn_specify_host_port, 1) with input as input
+	t.error_count(warn_specify_host_port, 1) with input as inp
 }

--- a/policy/lib.rego
+++ b/policy/lib.rego
@@ -1,29 +1,29 @@
 package lib
 
-has_key(obj, k) {
+import rego.v1
+
+has_key(obj, k) if {
 	_ = obj[k]
 }
 
-is_false(val) {
-	any([val == "false", val == false])
+is_false(val) if {
+	true in [val == "false", val == false]
 }
 
-is_true(val) {
-	any([val == "true", val == true])
+is_true(val) if {
+	true in [val == "true", val == true]
 }
 
-not_existing_or_true(obj, k) {
+not_existing_or_true(obj, k) if {
 	not has_key(obj, k)
-} else {
+} else if {
 	is_true(obj[k])
 }
 
-contains_element(arr, elem) {
+contains_element(arr, elem) if {
 	arr[_] = elem
-} else = false {
-	true
-}
+} else := false
 
-get_url(check) = url {
+get_url(check) := url if {
 	url := sprintf("https://github.com/EmbarkStudios/opa-policies/wiki/%s", [check])
 }

--- a/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_binding.rego
+++ b/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check50 := "TF_GCP_50"
 
 # DENY(TF_GCP_50)
-deny_artifactregistry_public_iam_binding[msg] {
+deny_artifactregistry_public_iam_binding contains msg if {
 	input.resource.google_artifact_registry_repository_iam_binding
 	binding := input.resource.google_artifact_registry_repository_iam_binding[k]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_binding_test.rego
+++ b/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_binding_test.rego
@@ -1,63 +1,49 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_artifactregistry_public_iam_binding {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_binding": {
-                "public-member": {
-                    "repository": "ds",
-                    "role": "roles/viewer",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_artifactregistry_public_iam_binding if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_binding": {"public-member": {
+		"repository": "ds",
+		"role": "roles/viewer",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.error_count(deny_artifactregistry_public_iam_binding, 1) with input as input
+	t.error_count(deny_artifactregistry_public_iam_binding, 1) with input as inp
 }
 
-test_not_deny_artifactregistry_public_iam_binding_when_exception {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_50",
-                    "repository": "test",
-                    "role": "roles/viewer",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_not_deny_artifactregistry_public_iam_binding_when_exception if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_binding": {"public-member": {
+		"//": "TF_GCP_50",
+		"repository": "test",
+		"role": "roles/viewer",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.no_errors(deny_artifactregistry_public_iam_binding) with input as input
+	t.no_errors(deny_artifactregistry_public_iam_binding) with input as inp
 }
 
-test_deny_artifactregistry_public_iam_binding_more_members {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_50",
-                    "repository": "test1",
-                    "role": "roles/viewer",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should be blocked": {
-                    "repository": "test2",
-                    "role": "roles/viewer",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should not be blocked": {
-                    "repository": "test3",
-                    "role": "roles/viewer",
-                    "members": ["group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_artifactregistry_public_iam_binding_more_members if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_50",
+			"repository": "test1",
+			"role": "roles/viewer",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should be blocked": {
+			"repository": "test2",
+			"role": "roles/viewer",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should not be blocked": {
+			"repository": "test3",
+			"role": "roles/viewer",
+			"members": ["group:test@embark.dev"],
+		},
+	}}}
 
-    t.error_count(deny_artifactregistry_public_iam_binding, 1) with input as input
+	t.error_count(deny_artifactregistry_public_iam_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_member.rego
+++ b/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check51 := "TF_GCP_51"
 
 # DENY(TF_GCP_51)
-deny_artifactregistry_public_iam_member[msg] {
+deny_artifactregistry_public_iam_member contains msg if {
 	input.resource.google_artifact_registry_repository_iam_member
 	member := input.resource.google_artifact_registry_repository_iam_member[_]
 	l.contains_element(blacklisted_users, member.member)

--- a/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_member_test.rego
+++ b/policy/terraform/gcp/ar/deny_artifactregistry_public_iam_member_test.rego
@@ -1,58 +1,44 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_artifactregistry_public_iam_member {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_member": {
-                "public-member": {
-                    "repository": "test",
-                    "role": "roles/viewer",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_artifactregistry_public_iam_member if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_member": {"public-member": {
+		"repository": "test",
+		"role": "roles/viewer",
+		"member": "allUsers",
+	}}}}
 
-    t.error_count(deny_artifactregistry_public_iam_member, 1) with input as input
+	t.error_count(deny_artifactregistry_public_iam_member, 1) with input as inp
 }
 
-test_not_deny_artifactregistry_public_iam_member_when_exception {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_51",
-                    "repository": "test",
-                    "role": "roles/viewer",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_not_deny_artifactregistry_public_iam_member_when_exception if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_member": {"public-member": {
+		"//": "TF_GCP_51",
+		"repository": "test",
+		"role": "roles/viewer",
+		"member": "allUsers",
+	}}}}
 
-    t.no_errors(deny_artifactregistry_public_iam_member) with input as input
+	t.no_errors(deny_artifactregistry_public_iam_member) with input as inp
 }
 
-test_deny_artifactregistry_public_iam_member_more_members {
-    input := {
-        "resource": {
-            "google_artifact_registry_repository_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_51",
-                    "repository": "test1",
-                    "role": "roles/viewer",
-                    "member": "allUsers"
-                },
-                "should be blocked": {
-                    "repository": "test2",
-                    "role": "roles/viewer",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_artifactregistry_public_iam_member_more_members if {
+	inp := {"resource": {"google_artifact_registry_repository_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_51",
+			"repository": "test1",
+			"role": "roles/viewer",
+			"member": "allUsers",
+		},
+		"should be blocked": {
+			"repository": "test2",
+			"role": "roles/viewer",
+			"member": "allUsers",
+		},
+	}}}
 
-    t.error_count(deny_artifactregistry_public_iam_member, 1) with input as input
+	t.error_count(deny_artifactregistry_public_iam_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/bq/deny_dataset_public_iam_binding.rego
+++ b/policy/terraform/gcp/bq/deny_dataset_public_iam_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check09 := "TF_GCP_09"
 
 # DENY(TF_GCP_09)
-deny_dataset_public_iam_binding[msg] {
+deny_dataset_public_iam_binding contains msg if {
 	input.resource.google_bigquery_dataset_iam_binding
 	binding := input.resource.google_bigquery_dataset_iam_binding[k]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/bq/deny_dataset_public_iam_binding_test.rego
+++ b/policy/terraform/gcp/bq/deny_dataset_public_iam_binding_test.rego
@@ -1,63 +1,49 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_dataset_public_iam_binding {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_binding": {
-                "public-member": {
-                    "dataset_id": "ds",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_dataset_public_iam_binding if {
+	inp := {"resource": {"google_bigquery_dataset_iam_binding": {"public-member": {
+		"dataset_id": "ds",
+		"role": "roles/bigquery.dataEditor",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.error_count(deny_dataset_public_iam_binding, 1) with input as input
+	t.error_count(deny_dataset_public_iam_binding, 1) with input as inp
 }
 
-test_not_deny_dataset_public_iam_binding_when_exception {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_09",
-                    "dataset_id": "ds",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_not_deny_dataset_public_iam_binding_when_exception if {
+	inp := {"resource": {"google_bigquery_dataset_iam_binding": {"public-member": {
+		"//": "TF_GCP_09",
+		"dataset_id": "ds",
+		"role": "roles/bigquery.dataEditor",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.no_errors(deny_dataset_public_iam_binding) with input as input
+	t.no_errors(deny_dataset_public_iam_binding) with input as inp
 }
 
-test_deny_dataset_public_iam_binding_more_members {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_09",
-                    "dataset_id": "ds1",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should be blocked": {
-                    "dataset_id": "ds2",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should not be blocked": {
-                    "dataset_id": "ds3",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_dataset_public_iam_binding_more_members if {
+	inp := {"resource": {"google_bigquery_dataset_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_09",
+			"dataset_id": "ds1",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should be blocked": {
+			"dataset_id": "ds2",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should not be blocked": {
+			"dataset_id": "ds3",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["group:test@embark.dev"],
+		},
+	}}}
 
-    t.error_count(deny_dataset_public_iam_binding, 1) with input as input
+	t.error_count(deny_dataset_public_iam_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/bq/deny_dataset_public_iam_member.rego
+++ b/policy/terraform/gcp/bq/deny_dataset_public_iam_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check07 := "TF_GCP_07"
 
 # DENY(TF_GCP_07)
-deny_dataset_public_iam_member[msg] {
+deny_dataset_public_iam_member contains msg if {
 	input.resource.google_bigquery_dataset_iam_member
 	member := input.resource.google_bigquery_dataset_iam_member[_]
 	l.contains_element(blacklisted_users, member.member)

--- a/policy/terraform/gcp/bq/deny_dataset_public_iam_member_test.rego
+++ b/policy/terraform/gcp/bq/deny_dataset_public_iam_member_test.rego
@@ -1,58 +1,44 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_dataset_public_iam_member {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_member": {
-                "public-member": {
-                    "dataset_id": "ds",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_dataset_public_iam_member if {
+	inp := {"resource": {"google_bigquery_dataset_iam_member": {"public-member": {
+		"dataset_id": "ds",
+		"role": "roles/bigquery.dataEditor",
+		"member": "allUsers",
+	}}}}
 
-    t.error_count(deny_dataset_public_iam_member, 1) with input as input
+	t.error_count(deny_dataset_public_iam_member, 1) with input as inp
 }
 
-test_not_deny_dataset_public_iam_member_when_exception {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_07",
-                    "dataset_id": "ds",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_not_deny_dataset_public_iam_member_when_exception if {
+	inp := {"resource": {"google_bigquery_dataset_iam_member": {"public-member": {
+		"//": "TF_GCP_07",
+		"dataset_id": "ds",
+		"role": "roles/bigquery.dataEditor",
+		"member": "allUsers",
+	}}}}
 
-    t.no_errors(deny_dataset_public_iam_member) with input as input
+	t.no_errors(deny_dataset_public_iam_member) with input as inp
 }
 
-test_deny_dataset_public_iam_member_more_members {
-    input := {
-        "resource": {
-            "google_bigquery_dataset_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_07",
-                    "dataset_id": "ds",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                },
-                "should be blocked": {
-                    "dataset_id": "ds2",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_dataset_public_iam_member_more_members if {
+	inp := {"resource": {"google_bigquery_dataset_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_07",
+			"dataset_id": "ds",
+			"role": "roles/bigquery.dataEditor",
+			"member": "allUsers",
+		},
+		"should be blocked": {
+			"dataset_id": "ds2",
+			"role": "roles/bigquery.dataEditor",
+			"member": "allUsers",
+		},
+	}}}
 
-    t.error_count(deny_dataset_public_iam_member, 1) with input as input
+	t.error_count(deny_dataset_public_iam_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/bq/deny_table_public_iam_binding.rego
+++ b/policy/terraform/gcp/bq/deny_table_public_iam_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check10 := "TF_GCP_10"
 
 # DENY(TF_GCP_10)
-deny_table_public_iam_binding[msg] {
+deny_table_public_iam_binding contains msg if {
 	input.resource.google_bigquery_table_iam_binding
 	binding := input.resource.google_bigquery_table_iam_binding[k]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/bq/deny_table_public_iam_binding_test.rego
+++ b/policy/terraform/gcp/bq/deny_table_public_iam_binding_test.rego
@@ -1,68 +1,54 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_table_public_iam_binding {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_binding": {
-                "public-member": {
-                    "dataset_id": "ds",
-                    "table_id": "x",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_table_public_iam_binding if {
+	inp := {"resource": {"google_bigquery_table_iam_binding": {"public-member": {
+		"dataset_id": "ds",
+		"table_id": "x",
+		"role": "roles/bigquery.dataEditor",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.error_count(deny_table_public_iam_binding, 1) with input as input
+	t.error_count(deny_table_public_iam_binding, 1) with input as inp
 }
 
-test_not_deny_table_public_iam_binding_when_exception {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_10",
-                    "dataset_id": "ds",
-                    "table_id": "x",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_not_deny_table_public_iam_binding_when_exception if {
+	inp := {"resource": {"google_bigquery_table_iam_binding": {"public-member": {
+		"//": "TF_GCP_10",
+		"dataset_id": "ds",
+		"table_id": "x",
+		"role": "roles/bigquery.dataEditor",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.no_errors(deny_table_public_iam_binding) with input as input
+	t.no_errors(deny_table_public_iam_binding) with input as inp
 }
 
-test_deny_table_public_iam_binding_more_members {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_10",
-                    "dataset_id": "ds1",
-                    "table_id": "x",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should be blocked": {
-                    "dataset_id": "ds2",
-                    "table_id": "x",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should not be blocked": {
-                    "dataset_id": "ds3",
-                    "table_id": "x",
-                    "role": "roles/bigquery.dataEditor",
-                    "members": ["group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_table_public_iam_binding_more_members if {
+	inp := {"resource": {"google_bigquery_table_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_10",
+			"dataset_id": "ds1",
+			"table_id": "x",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should be blocked": {
+			"dataset_id": "ds2",
+			"table_id": "x",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should not be blocked": {
+			"dataset_id": "ds3",
+			"table_id": "x",
+			"role": "roles/bigquery.dataEditor",
+			"members": ["group:test@embark.dev"],
+		},
+	}}}
 
-    t.error_count(deny_table_public_iam_binding, 1) with input as input
+	t.error_count(deny_table_public_iam_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/bq/deny_table_public_iam_member.rego
+++ b/policy/terraform/gcp/bq/deny_table_public_iam_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check08 := "TF_GCP_08"
 
 # DENY(TF_GCP_08)
-deny_table_public_iam_member[msg] {
+deny_table_public_iam_member contains msg if {
 	input.resource.google_bigquery_table_iam_member
 	member := input.resource.google_bigquery_table_iam_member[k]
 	l.contains_element(blacklisted_users, member.member)

--- a/policy/terraform/gcp/bq/deny_table_public_iam_member_test.rego
+++ b/policy/terraform/gcp/bq/deny_table_public_iam_member_test.rego
@@ -1,62 +1,48 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_table_public_iam_member {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_member": {
-                "public-member": {
-                    "dataset_id": "ds",
-                    "table_id": "t",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_table_public_iam_member if {
+	inp := {"resource": {"google_bigquery_table_iam_member": {"public-member": {
+		"dataset_id": "ds",
+		"table_id": "t",
+		"role": "roles/bigquery.dataEditor",
+		"member": "allUsers",
+	}}}}
 
-    t.error_count(deny_table_public_iam_member, 1) with input as input
+	t.error_count(deny_table_public_iam_member, 1) with input as inp
 }
 
-test_not_deny_table_public_iam_member_when_exception {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_08",
-                    "dataset_id": "ds",
-                    "table_id": "t",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_not_deny_table_public_iam_member_when_exception if {
+	inp := {"resource": {"google_bigquery_table_iam_member": {"public-member": {
+		"//": "TF_GCP_08",
+		"dataset_id": "ds",
+		"table_id": "t",
+		"role": "roles/bigquery.dataEditor",
+		"member": "allUsers",
+	}}}}
 
-    t.no_errors(deny_table_public_iam_member) with input as input
+	t.no_errors(deny_table_public_iam_member) with input as inp
 }
 
-test_deny_table_public_iam_member_more_members {
-    input := {
-        "resource": {
-            "google_bigquery_table_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_08",
-                    "dataset_id": "ds",
-                    "table_id": "t",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                },
-                "should be blocked": {
-                    "dataset_id": "ds2",
-                    "table_id": "t",
-                    "role": "roles/bigquery.dataEditor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_table_public_iam_member_more_members if {
+	inp := {"resource": {"google_bigquery_table_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_08",
+			"dataset_id": "ds",
+			"table_id": "t",
+			"role": "roles/bigquery.dataEditor",
+			"member": "allUsers",
+		},
+		"should be blocked": {
+			"dataset_id": "ds2",
+			"table_id": "t",
+			"role": "roles/bigquery.dataEditor",
+			"member": "allUsers",
+		},
+	}}}
 
-    t.error_count(deny_table_public_iam_member, 1) with input as input
+	t.error_count(deny_table_public_iam_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_auto_disk_resize.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_auto_disk_resize.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check47 := "TF_GCP_47"
 
 # DENY(TF_GCP_47)
-deny_cloudsql_auto_disk_resize[msg] {
+deny_cloudsql_auto_disk_resize contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check47, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_auto_disk_resize_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_auto_disk_resize_test.rego
@@ -1,76 +1,42 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_auto_disk_resize_as_string {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "disk_autoresize": "false"
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_auto_disk_resize_as_string if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"disk_autoresize": "false"},
+	}}}}
 
-    t.error_count(deny_cloudsql_auto_disk_resize, 1) with input as input
+	t.error_count(deny_cloudsql_auto_disk_resize, 1) with input as inp
 }
 
-test_not_deny_cloudsql_auto_disk_resize {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "disk_autoresize": false
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_auto_disk_resize if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"disk_autoresize": false},
+	}}}}
 
-    t.error_count(deny_cloudsql_auto_disk_resize, 1) with input as input
+	t.error_count(deny_cloudsql_auto_disk_resize, 1) with input as inp
 }
 
-test_not_deny_cloudsql_auto_disk_resize_no_prop {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "backup_retention_settings": {
-                                "retained_backups": 14
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_auto_disk_resize_no_prop if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"backup_retention_settings": {"retained_backups": 14}}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_auto_disk_resize) with input as input
+	t.no_errors(deny_cloudsql_auto_disk_resize) with input as inp
 }
 
-test_not_deny_cloudsql_auto_disk_resize_when_exception {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "//": "TF_GCP_47",
-                    "name": "test",
-                    "settings": {
-                        "disk_autoresize": "false"
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_auto_disk_resize_when_exception if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"//": "TF_GCP_47",
+		"name": "test",
+		"settings": {"disk_autoresize": "false"},
+	}}}}
 
-    t.no_errors(deny_cloudsql_auto_disk_resize) with input as input
+	t.no_errors(deny_cloudsql_auto_disk_resize) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_availability_type.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_availability_type.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check48 := "TF_GCP_48"
 
 # DENY(TF_GCP_48)
-deny_cloudsql_availability_type[msg] {
+deny_cloudsql_availability_type contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check48, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_availability_type_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_availability_type_test.rego
@@ -1,70 +1,42 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_availability_type {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "availability_type": "REGIONAL"
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_availability_type if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"availability_type": "REGIONAL"},
+	}}}}
 
-    t.no_errors(deny_cloudsql_availability_type) with input as input
+	t.no_errors(deny_cloudsql_availability_type) with input as inp
 }
 
-test_deny_cloudsql_availability_type_without_conf {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {}
-                }
-            }
-        }
-    }
+test_deny_cloudsql_availability_type_without_conf if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {},
+	}}}}
 
-    t.error_count(deny_cloudsql_availability_type, 1) with input as input
+	t.error_count(deny_cloudsql_availability_type, 1) with input as inp
 }
 
-test_deny_cloudsql_availability_type_zonal {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "availability_type": "ZONAL"
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_availability_type_zonal if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"availability_type": "ZONAL"},
+	}}}}
 
-    t.error_count(deny_cloudsql_availability_type, 1) with input as input
+	t.error_count(deny_cloudsql_availability_type, 1) with input as inp
 }
 
-test_not_deny_cloudsql_availability_type_zonal_with_exception {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "//": "TF_GCP_48",
-                    "name": "test",
-                    "settings": {
-                        "availability_type": "ZONAL"
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_availability_type_zonal_with_exception if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"//": "TF_GCP_48",
+		"name": "test",
+		"settings": {"availability_type": "ZONAL"},
+	}}}}
 
-    t.no_errors(deny_cloudsql_availability_type) with input as input
+	t.no_errors(deny_cloudsql_availability_type) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_backup.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_backup.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check46 := "TF_GCP_46"
 
-no_backup_config(instance) {
+no_backup_config(instance) if {
 	not instance.settings.backup_configuration
-} else {
+} else if {
 	l.is_false(instance.settings.backup_configuration.enabled)
 }
 
 # DENY(TF_GCP_46)
-deny_cloudsql_no_backup[msg] {
+deny_cloudsql_no_backup contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check46, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_backup_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_backup_test.rego
@@ -1,135 +1,69 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_no_backup {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "enabled": true
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_backup if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"enabled": true}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_no_backup) with input as input
+	t.no_errors(deny_cloudsql_no_backup) with input as inp
 }
 
-test_deny_cloudsql_no_backup_without_conf {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {}
-                }
-            }
-        }
-    }
+test_deny_cloudsql_no_backup_without_conf if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {},
+	}}}}
 
-    t.error_count(deny_cloudsql_no_backup, 1) with input as input
+	t.error_count(deny_cloudsql_no_backup, 1) with input as inp
 }
 
-test_not_deny_cloudsql_no_backup_as_string {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "enabled": "true"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_backup_as_string if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"enabled": "true"}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_no_backup) with input as input
+	t.no_errors(deny_cloudsql_no_backup) with input as inp
 }
 
-test_not_deny_cloudsql_no_backup_no_prop {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "backup_retention_settings": {
-                                "retained_backups": 14
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_backup_no_prop if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"backup_retention_settings": {"retained_backups": 14}}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_no_backup) with input as input
+	t.no_errors(deny_cloudsql_no_backup) with input as inp
 }
 
-test_not_deny_cloudsql_no_backup_when_exception {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "//": "TF_GCP_46",
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "enabled": "false",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_backup_when_exception if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"//": "TF_GCP_46",
+		"name": "test",
+		"settings": {"backup_configuration": {"enabled": "false"}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_no_backup) with input as input
+	t.no_errors(deny_cloudsql_no_backup) with input as inp
 }
 
-test_deny_deny_cloudsql_no_backup_with_string {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "enabled": "false",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_deny_cloudsql_no_backup_with_string if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"enabled": "false"}},
+	}}}}
 
-    t.error_count(deny_cloudsql_no_backup, 1) with input as input
+	t.error_count(deny_cloudsql_no_backup, 1) with input as inp
 }
 
-test_deny_deny_cloudsql_no_backup {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "settings": {
-                        "backup_configuration": {
-                            "enabled": false,
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_deny_cloudsql_no_backup if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"settings": {"backup_configuration": {"enabled": false}},
+	}}}}
 
-    t.error_count(deny_cloudsql_no_backup, 1) with input as input
+	t.error_count(deny_cloudsql_no_backup, 1) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_mysql_flags.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_mysql_flags.rego
@@ -1,5 +1,7 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
@@ -8,7 +10,7 @@ check53 := "TF_GCP_53"
 mysql_expected_flags := {{"name": "local_infile", "value": "off"}}
 
 # DENY(TF_GCP_53)
-deny_cloudsql_mysql_flags[msg] {
+deny_cloudsql_mysql_flags contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check53, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_mysql_flags_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_mysql_flags_test.rego
@@ -1,119 +1,69 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_mysql_flags {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "local_infile", "value": "off"}
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_mysql_flags if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {"database_flags": [{"name": "local_infile", "value": "off"}]},
+	}}}}
 
-    t.no_errors(deny_cloudsql_mysql_flags) with input as input
+	t.no_errors(deny_cloudsql_mysql_flags) with input as inp
 }
 
-test_deny_cloudsql_mysql_flags_empty {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                        "database_flags": []
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_mysql_flags_empty if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {"database_flags": []},
+	}}}}
 
-    t.error_count(deny_cloudsql_mysql_flags, 1) with input as input
+	t.error_count(deny_cloudsql_mysql_flags, 1) with input as inp
 }
 
-test_deny_cloudsql_mysql_flags_no_prop {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_mysql_flags_no_prop if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {},
+	}}}}
 
-    t.error_count(deny_cloudsql_mysql_flags, 1) with input as input
+	t.error_count(deny_cloudsql_mysql_flags, 1) with input as inp
 }
 
+test_not_deny_cloudsql_mysql_flags_when_exception if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"//": "TF_GCP_53",
+		"settings": {"database_flags": []},
+	}}}}
 
-test_not_deny_cloudsql_mysql_flags_when_exception {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "//": "TF_GCP_53",
-                    "settings": {
-                        "database_flags": []
-                    }
-                }
-            }
-        }
-    }
-
-    t.no_errors(deny_cloudsql_mysql_flags) with input as input
+	t.no_errors(deny_cloudsql_mysql_flags) with input as inp
 }
 
-test_deny_cloudsql_mysql_flags_wrong_flag {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "not_existing", "value": "off"}
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_mysql_flags_wrong_flag if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {"database_flags": [{"name": "not_existing", "value": "off"}]},
+	}}}}
 
-    t.error_count(deny_cloudsql_mysql_flags, 1) with input as input
+	t.error_count(deny_cloudsql_mysql_flags, 1) with input as inp
 }
 
-test_not_deny_cloudsql_mysql_flags_multiple {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "local_infile", "value": "off"},
-                            {"name": "not_existing", "value": "off"}
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_mysql_flags_multiple if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {"database_flags": [
+			{"name": "local_infile", "value": "off"},
+			{"name": "not_existing", "value": "off"},
+		]},
+	}}}}
 
-    t.no_errors(deny_cloudsql_mysql_flags) with input as input
+	t.no_errors(deny_cloudsql_mysql_flags) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_point_in_time_recovery.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_point_in_time_recovery.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check52 := "TF_GCP_52"
 
-no_pitr(instance) {
+no_pitr(instance) if {
 	not instance.settings.backup_configuration.point_in_time_recovery_enabled
-} else {
+} else if {
 	not l.is_true(instance.settings.backup_configuration.point_in_time_recovery_enabled)
 }
 
 # DENY(TF_GCP_46)
-deny_cloudsql_point_in_time_recovery[msg] {
+deny_cloudsql_point_in_time_recovery contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check52, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_point_in_time_recovery_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_point_in_time_recovery_test.rego
@@ -1,162 +1,86 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_with_pitr {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": true
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_with_pitr if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": true}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_point_in_time_recovery) with input as input
+	t.no_errors(deny_cloudsql_point_in_time_recovery) with input as inp
 }
 
-test_deny_cloudsql_no_pitr_without_conf {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {}
-                }
-            }
-        }
-    }
+test_deny_cloudsql_no_pitr_without_conf if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {},
+	}}}}
 
-    t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as input
+	t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as inp
 }
 
-test_not_deny_cloudsql_pitr_as_string {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": "true"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_pitr_as_string if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": "true"}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_point_in_time_recovery) with input as input
+	t.no_errors(deny_cloudsql_point_in_time_recovery) with input as inp
 }
 
-test_deny_cloudsql_pitr_no_prop {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "backup_retention_settings": {
-                                "retained_backups": 14
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_pitr_no_prop if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"backup_retention_settings": {"retained_backups": 14}}},
+	}}}}
 
-    t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as input
+	t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as inp
 }
 
-test_not_deny_cloudsql_no_pitr_when_exception {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "//": "TF_GCP_52",
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": "false",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_pitr_when_exception if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"//": "TF_GCP_52",
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": "false"}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_point_in_time_recovery) with input as input
+	t.no_errors(deny_cloudsql_point_in_time_recovery) with input as inp
 }
 
-test_deny_cloudsql_no_pitr_with_string {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": "false",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_no_pitr_with_string if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": "false"}},
+	}}}}
 
-    t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as input
+	t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as inp
 }
 
-test_deny_cloudsql_no_pitr {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": false,
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_no_pitr if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": false}},
+	}}}}
 
-    t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as input
+	t.error_count(deny_cloudsql_point_in_time_recovery, 1) with input as inp
 }
 
-test_not_deny_cloudsql_no_pitr_when_not_postgres {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "MYSQL_8_0",
-                    "settings": {
-                        "backup_configuration": {
-                            "point_in_time_recovery_enabled": "false",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_no_pitr_when_not_postgres if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "MYSQL_8_0",
+		"settings": {"backup_configuration": {"point_in_time_recovery_enabled": "false"}},
+	}}}}
 
-    t.no_errors(deny_cloudsql_point_in_time_recovery) with input as input
+	t.no_errors(deny_cloudsql_point_in_time_recovery) with input as inp
 }

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_postgres_flags.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_postgres_flags.rego
@@ -1,5 +1,7 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
@@ -15,7 +17,7 @@ postgres_expected_flags := {
 }
 
 # DENY(TF_GCP_54)
-deny_cloudsql_postgres_flags[msg] {
+deny_cloudsql_postgres_flags contains msg if {
 	input.resource.google_sql_database_instance
 	instance := input.resource.google_sql_database_instance[i]
 	not make_exception(check54, instance)

--- a/policy/terraform/gcp/cloudsql/deny_cloudsql_postgres_flags_test.rego
+++ b/policy/terraform/gcp/cloudsql/deny_cloudsql_postgres_flags_test.rego
@@ -1,115 +1,79 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_cloudsql_postgres_flags {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "log_checkpoints", "value": "on"},
-                            {"name": "log_connections", "value": "on"},
-                            {"name": "log_disconnections", "value": "on"},
-                            {"name": "log_lock_waits", "value": "on"},
-                            {"name": "log_temp_files", "value": "0"},
-                            {"name": "log_min_duration_statement", "value": "-1"}
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_postgres_flags if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"database_flags": [
+			{"name": "log_checkpoints", "value": "on"},
+			{"name": "log_connections", "value": "on"},
+			{"name": "log_disconnections", "value": "on"},
+			{"name": "log_lock_waits", "value": "on"},
+			{"name": "log_temp_files", "value": "0"},
+			{"name": "log_min_duration_statement", "value": "-1"},
+		]},
+	}}}}
 
-    t.no_errors(deny_cloudsql_postgres_flags) with input as input
+	t.no_errors(deny_cloudsql_postgres_flags) with input as inp
 }
 
-test_not_deny_cloudsql_postgres_flags {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "SQLSERVER_2019_STANDARD",
-                    "settings": {}
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_postgres_flags if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "SQLSERVER_2019_STANDARD",
+		"settings": {},
+	}}}}
 
-    t.no_errors(deny_cloudsql_postgres_flags) with input as input
+	t.no_errors(deny_cloudsql_postgres_flags) with input as inp
 }
 
-test_not_deny_cloudsql_postgres_flags_additional_flag {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "log_disconnections", "value": "on"},
-                            {"name": "log_connections", "value": "on"},
-                            {"name": "log_checkpoints", "value": "on"},
-                            {"name": "log_lock_waits", "value": "on"},
-                            {"name": "log_temp_files", "value": "0"},
-                            {"name": "log_min_duration_statement", "value": "-1"},
-                            {"name": "a_flag", "value": "on"}
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_postgres_flags_additional_flag if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"database_flags": [
+			{"name": "log_disconnections", "value": "on"},
+			{"name": "log_connections", "value": "on"},
+			{"name": "log_checkpoints", "value": "on"},
+			{"name": "log_lock_waits", "value": "on"},
+			{"name": "log_temp_files", "value": "0"},
+			{"name": "log_min_duration_statement", "value": "-1"},
+			{"name": "a_flag", "value": "on"},
+		]},
+	}}}}
 
-    t.no_errors(deny_cloudsql_postgres_flags) with input as input
+	t.no_errors(deny_cloudsql_postgres_flags) with input as inp
 }
 
-test_deny_cloudsql_postgres_flags_missing {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "log_checkpoints", "value": "on"},
-                            {"name": "log_connections", "value": "on"},
-                            {"name": "log_disconnections", "value": "on"},
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_deny_cloudsql_postgres_flags_missing if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"database_flags": [
+			{"name": "log_checkpoints", "value": "on"},
+			{"name": "log_connections", "value": "on"},
+			{"name": "log_disconnections", "value": "on"},
+		]},
+	}}}}
 
-    t.error_count(deny_cloudsql_postgres_flags, 1) with input as input
+	t.error_count(deny_cloudsql_postgres_flags, 1) with input as inp
 }
 
-test_not_deny_cloudsql_postgres_flags_missing {
-    input := {
-        "resource": {
-            "google_sql_database_instance": {
-                "test": {
-                    "//":"TF_GCP_54",
-                    "name": "test",
-                    "database_version": "POSTGRES_13",
-                    "settings": {
-                        "database_flags": [
-                            {"name": "log_checkpoints", "value": "on"},
-                            {"name": "log_connections", "value": "on"},
-                            {"name": "log_disconnections", "value": "on"},
-                        ]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_cloudsql_postgres_flags_missing if {
+	inp := {"resource": {"google_sql_database_instance": {"test": {
+		"//": "TF_GCP_54",
+		"name": "test",
+		"database_version": "POSTGRES_13",
+		"settings": {"database_flags": [
+			{"name": "log_checkpoints", "value": "on"},
+			{"name": "log_connections", "value": "on"},
+			{"name": "log_disconnections", "value": "on"},
+		]},
+	}}}}
 
-    t.no_errors(deny_cloudsql_postgres_flags) with input as input
+	t.no_errors(deny_cloudsql_postgres_flags) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_firewall_unrestricted.rego
+++ b/policy/terraform/gcp/gce/deny_compute_firewall_unrestricted.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check14 := "TF_GCP_14"
 
 # DENY(TF_GCP_14)
-deny_compute_firewall_unrestricted[msg] {
+deny_compute_firewall_unrestricted contains msg if {
 	input.resource.google_compute_firewall
 	f := input.resource.google_compute_firewall[i]
 	f.allow

--- a/policy/terraform/gcp/gce/deny_compute_firewall_unrestricted_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_firewall_unrestricted_test.rego
@@ -1,91 +1,59 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_firewall_unrestricted {
-    input := {
-        "resource": {
-            "google_compute_firewall": {
-                "f1": {
-                    "name": "f1",
-                    "source_ranges": ["0.0.0.0/0"],
-                    "allow": {
-                        "ports":["22", "5432"]
-                    }
-                }
-            }
-        }
-    }
+test_deny_compute_firewall_unrestricted if {
+	inp := {"resource": {"google_compute_firewall": {"f1": {
+		"name": "f1",
+		"source_ranges": ["0.0.0.0/0"],
+		"allow": {"ports": ["22", "5432"]},
+	}}}}
 
-    t.error_count(deny_compute_firewall_unrestricted, 1) with input as input
+	t.error_count(deny_compute_firewall_unrestricted, 1) with input as inp
 }
 
-test_not_deny_compute_firewall_unrestricted_when_no_allow {
-    input := {
-        "resource": {
-            "google_compute_firewall": {
-                "f1": {
-                    "name": "f1",
-                    "source_ranges": ["0.0.0.0/0"],
-                    "deny": {
-                        "ports":["22", "5432"]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_compute_firewall_unrestricted_when_no_allow if {
+	inp := {"resource": {"google_compute_firewall": {"f1": {
+		"name": "f1",
+		"source_ranges": ["0.0.0.0/0"],
+		"deny": {"ports": ["22", "5432"]},
+	}}}}
 
-    t.no_errors(deny_compute_firewall_unrestricted) with input as input
+	t.no_errors(deny_compute_firewall_unrestricted) with input as inp
 }
 
-test_not_deny_compute_firewall_unrestricted_when_exception {
-    input := {
-        "resource": {
-            "google_compute_firewall": {
-                "p1": {
-                    "//": "TF_GCP_14",
-                    "name": "f1",
-                    "source_ranges": ["0.0.0.0/0"],
-                    "allow": {
-                        "ports":["22", "5432"]
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_compute_firewall_unrestricted_when_exception if {
+	inp := {"resource": {"google_compute_firewall": {"p1": {
+		"//": "TF_GCP_14",
+		"name": "f1",
+		"source_ranges": ["0.0.0.0/0"],
+		"allow": {"ports": ["22", "5432"]},
+	}}}}
 
-    t.no_errors(deny_compute_firewall_unrestricted) with input as input
+	t.no_errors(deny_compute_firewall_unrestricted) with input as inp
 }
 
-test_deny_compute_firewall_unrestricted_multiple {
-    input := {
-        "resource": {
-            "google_compute_firewall": {
-                "f1": {
-                    "//": "TF_GCP_14",
-                    "name": "f1",
-                    "source_ranges": ["0.0.0.0/0"],
-                    "allow": {
-                        "ports":["22", "5432"]
-                    }
-                },
-                "f2": {
-                   	"name": "f2",
-                    "source_ranges": ["0.0.0.0/0"],
-                    "allow": {
-                        "ports":["22", "5432"]
-                    }
-                },
-                "f3": {
-                    "name": "f3",
-                    "source_ranges": ["35.191.0.0/16"],
-                    "allow": {
-                        "ports":["22", "5432"]
-                    }
-                }
-            }
-        }
-    }
+test_deny_compute_firewall_unrestricted_multiple if {
+	inp := {"resource": {"google_compute_firewall": {
+		"f1": {
+			"//": "TF_GCP_14",
+			"name": "f1",
+			"source_ranges": ["0.0.0.0/0"],
+			"allow": {"ports": ["22", "5432"]},
+		},
+		"f2": {
+			"name": "f2",
+			"source_ranges": ["0.0.0.0/0"],
+			"allow": {"ports": ["22", "5432"]},
+		},
+		"f3": {
+			"name": "f3",
+			"source_ranges": ["35.191.0.0/16"],
+			"allow": {"ports": ["22", "5432"]},
+		},
+	}}}
 
-    t.error_count(deny_compute_firewall_unrestricted, 1) with input as input
+	t.error_count(deny_compute_firewall_unrestricted, 1) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_instance_default_service_account.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_default_service_account.rego
@@ -1,19 +1,21 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check36 := "TF_GCP_36"
 
-instance_using_default_svc_acc(instance) {
+instance_using_default_svc_acc(instance) if {
 	not instance.service_account
-} else {
+} else if {
 	svc_acc := instance.service_account.email
 	regex.match(default_service_account_regexp, svc_acc)
 }
 
 # DENY(TF_GCP_36)
-deny_compute_instance_default_service_account[msg] {
+deny_compute_instance_default_service_account contains msg if {
 	input.resource.google_compute_instance
 	instance := input.resource.google_compute_instance[_]
 	not make_exception(check36, instance)

--- a/policy/terraform/gcp/gce/deny_compute_instance_default_service_account_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_default_service_account_test.rego
@@ -1,82 +1,47 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_instance_default_service_account {
-	input := {
-		"resource": {
-			"google_compute_instance": {
-				"no_svc_acc": {
-					"name": "no_svc_acc",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
+test_deny_compute_instance_default_service_account if {
+	inp := {"resource": {"google_compute_instance": {
+		"no_svc_acc": {
+			"name": "no_svc_acc",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+		},
+		"default_svc_acc": {
+			"name": "default_svc_acc",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"service_account": {"email": "000000000000-compute@developer.gserviceaccount.com"},
+		},
+	}}}
 
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-				},
-				"default_svc_acc": {
-					"name": "default_svc_acc",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
-
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"service_account": {
-						"email": "000000000000-compute@developer.gserviceaccount.com"
-					}
-				},
-			}
-		}
-	}
-
-	t.error_count(deny_compute_instance_default_service_account, 2) with input as input
+	t.error_count(deny_compute_instance_default_service_account, 2) with input as inp
 }
 
-test_allow_valid_compute_instance_service_account {
-	input := {
-		"resource": {
-			"google_compute_instance": {
-				"valid": {
-					"name": "valid",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
+test_allow_valid_compute_instance_service_account if {
+	inp := {"resource": {"google_compute_instance": {
+		"valid": {
+			"name": "valid",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"service_account": {"email": "my-service@my-project.iam.gserviceaccount.com"},
+		},
+		"excepted": {
+			"name": "excepted",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"//": "TF_GCP_36",
+			"service_account": {"email": "000000000000-compute@developer.gserviceaccount.com"},
+		},
+	}}}
 
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"service_account": {
-						"email": "my-service@my-project.iam.gserviceaccount.com"
-					}
-				},
-				"excepted": {
-					"name": "excepted",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
-
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"//": "TF_GCP_36",
-					"service_account": {
-						"email": "000000000000-compute@developer.gserviceaccount.com"
-					}
-				},
-			}
-		}
-	}
-
-	t.no_errors(deny_compute_instance_default_service_account) with input as input
+	t.no_errors(deny_compute_instance_default_service_account) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_instance_oslogin_disabled.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_oslogin_disabled.rego
@@ -1,19 +1,21 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check39 := "TF_GCP_39"
 
-oslogin_not_enabled(instance) {
+oslogin_not_enabled(instance) if {
 	not instance.metadata["enable-oslogin"]
-} else {
+} else if {
 	oslogin_enabled := instance.metadata["enable-oslogin"]
 	oslogin_enabled != "TRUE"
 }
 
 # DENY(TF_GCP_39)
-deny_compute_instance_oslogin_disabled[msg] {
+deny_compute_instance_oslogin_disabled contains msg if {
 	input.resource.google_compute_instance
 	instance := input.resource.google_compute_instance[_]
 

--- a/policy/terraform/gcp/gce/deny_compute_instance_oslogin_disabled_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_oslogin_disabled_test.rego
@@ -1,79 +1,46 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_instance_oslogin_disabled {
-	input := {
-		"resource": {
-			"google_compute_instance": {
-				"not_set": {
-					"name": "not_set",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
+test_deny_compute_instance_oslogin_disabled if {
+	inp := {"resource": {"google_compute_instance": {
+		"not_set": {
+			"name": "not_set",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+		},
+		"disabled": {
+			"name": "disabled",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"metadata": {"enable-oslogin": "FALSE"},
+		},
+	}}}
 
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-				},
-				"disabled": {
-					"name": "disabled",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
-
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"metadata": {
-						"enable-oslogin": "FALSE",
-					},
-				},
-			}
-		}
-	}
-
-	t.error_count(deny_compute_instance_oslogin_disabled, 2) with input as input
+	t.error_count(deny_compute_instance_oslogin_disabled, 2) with input as inp
 }
 
-test_allow_compute_instance_oslogin_enabled {
-	input := {
-		"resource": {
-			"google_compute_instance": {
-				"valid": {
-					"name": "valid",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
+test_allow_compute_instance_oslogin_enabled if {
+	inp := {"resource": {"google_compute_instance": {
+		"valid": {
+			"name": "valid",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"metadata": {"enable-oslogin": "TRUE"},
+		},
+		"excepted": {
+			"name": "excepted",
+			"machine_type": "e2-medium",
+			"zone": "europe-west4-a",
+			"boot_disk": {"initialize_params": {"image": "debian-cloud/debian-9"}},
+			"//": "TF_GCP_39",
+		},
+	}}}
 
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"metadata": {
-						"enable-oslogin": "TRUE",
-					},
-				},
-				"excepted": {
-					"name": "excepted",
-					"machine_type": "e2-medium",
-					"zone": "europe-west4-a",
-
-					"boot_disk": {
-						"initialize_params": {
-							"image": "debian-cloud/debian-9",
-						}
-					},
-
-					"//": "TF_GCP_39",
-				},
-			}
-		}
-	}
-
-	t.no_errors(deny_compute_instance_oslogin_disabled) with input as input
+	t.no_errors(deny_compute_instance_oslogin_disabled) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_instance_unshielded_vm.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_unshielded_vm.rego
@@ -1,19 +1,21 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check20 := "TF_GCP_20"
 
-secure_boot_not_enabled(instance) {
+secure_boot_not_enabled(instance) if {
 	not instance.shielded_instance_config.secure_boot_enabled
-} else {
+} else if {
 	sbe := instance.shielded_instance_config.secure_boot_enabled
 	l.is_false(sbe)
 }
 
 # DENY(TF_GCP_20)
-deny_compute_instance_unshielded_vm[msg] {
+deny_compute_instance_unshielded_vm contains msg if {
 	input.resource.google_compute_instance
 	instance := input.resource.google_compute_instance[_]
 	not make_exception(check20, instance)

--- a/policy/terraform/gcp/gce/deny_compute_instance_unshielded_vm_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_instance_unshielded_vm_test.rego
@@ -1,118 +1,68 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_missing_shielded_instance_config {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "name": "deny_me"
-                }
-            }
-        }
-    }
+test_deny_missing_shielded_instance_config if {
+	inp := {"resource": {"google_compute_instance": {"i1": {"name": "deny_me"}}}}
 
-    t.error_count(deny_compute_instance_unshielded_vm, 1) with input as input
+	t.error_count(deny_compute_instance_unshielded_vm, 1) with input as inp
 }
 
-test_deny_shielded_instance_config_without_secure_boot_enabled {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "name": "deny_me",
-                    "shielded_instance_config": {}
-                }
-            }
-        }
-    }
+test_deny_shielded_instance_config_without_secure_boot_enabled if {
+	inp := {"resource": {"google_compute_instance": {"i1": {
+		"name": "deny_me",
+		"shielded_instance_config": {},
+	}}}}
 
-    t.error_count(deny_compute_instance_unshielded_vm, 1) with input as input
+	t.error_count(deny_compute_instance_unshielded_vm, 1) with input as inp
 }
 
-test_deny_shielded_instance_config_with_secure_boot_disabled {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "name": "deny_me",
-                    "shielded_instance_config": {
-                        "secure_boot_enabled": false
-                    }
-                }
-            }
-        }
-    }
+test_deny_shielded_instance_config_with_secure_boot_disabled if {
+	inp := {"resource": {"google_compute_instance": {"i1": {
+		"name": "deny_me",
+		"shielded_instance_config": {"secure_boot_enabled": false},
+	}}}}
 
-    t.error_count(deny_compute_instance_unshielded_vm, 1) with input as input
+	t.error_count(deny_compute_instance_unshielded_vm, 1) with input as inp
 }
 
-test_deny_shielded_instance_config_with_secure_boot_disabled_string {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "name": "deny_me",
-                    "shielded_instance_config": {
-                        "secure_boot_enabled": "false"
-                    }
-                }
-            }
-        }
-    }
+test_deny_shielded_instance_config_with_secure_boot_disabled_string if {
+	inp := {"resource": {"google_compute_instance": {"i1": {
+		"name": "deny_me",
+		"shielded_instance_config": {"secure_boot_enabled": "false"},
+	}}}}
 
-    t.error_count(deny_compute_instance_unshielded_vm, 1) with input as input
+	t.error_count(deny_compute_instance_unshielded_vm, 1) with input as inp
 }
 
-test_not_deny_with_exception {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "//": "TF_GCP_20",
-                    "name": "allow_me",
-                    "shielded_instance_config": {
-                        "secure_boot_enabled": false
-                    }
-                },
-                "i2": {
-                    "//": "TF_GCP_20",
-                    "name": "allow_me",
-                    "shielded_instance_config": {}
-                },
-                "i3": {
-                    "//": "TF_GCP_20",
-                    "name": "allow_me",
-                }
-            }
-        }
-    }
+test_not_deny_with_exception if {
+	inp := {"resource": {"google_compute_instance": {
+		"i1": {
+			"//": "TF_GCP_20",
+			"name": "allow_me",
+			"shielded_instance_config": {"secure_boot_enabled": false},
+		},
+		"i2": {
+			"//": "TF_GCP_20",
+			"name": "allow_me",
+			"shielded_instance_config": {},
+		},
+		"i3": {
+			"//": "TF_GCP_20",
+			"name": "allow_me",
+		},
+	}}}
 
-    t.no_errors(deny_compute_instance_unshielded_vm) with input as input
+	t.no_errors(deny_compute_instance_unshielded_vm) with input as inp
 }
 
-test_not_deny_secure_boot_enabled {
-    input := {
-        "resource": {
-            "google_compute_instance": {
-                "i1": {
-                    "name": "allow_me",
-                    "shielded_instance_config": {
-                        "secure_boot_enabled": true
-                    }
-                }
-            },
-            "google_compute_instance": {
-                "i2": {
-                    "name": "allow_me",
-                    "shielded_instance_config": {
-                        "secure_boot_enabled": "true",
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_secure_boot_enabled if {
+	inp := {"resource": {"google_compute_instance": {"i2": {
+		"name": "allow_me",
+		"shielded_instance_config": {"secure_boot_enabled": "true"},
+	}}}}
 
-    t.no_errors(deny_compute_instance_unshielded_vm) with input as input
+	t.no_errors(deny_compute_instance_unshielded_vm) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_network_auto_create_subnets.rego
+++ b/policy/terraform/gcp/gce/deny_compute_network_auto_create_subnets.rego
@@ -1,17 +1,19 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check42 := "TF_GCP_42"
 
-invalid_auto_create_subnets(network) {
+invalid_auto_create_subnets(network) if {
 	not l.has_key(network, "auto_create_subnetworks")
-} else {
+} else if {
 	network.auto_create_subnetworks != false
 }
 
-deny_compute_network_auto_create_subnets[msg] {
+deny_compute_network_auto_create_subnets contains msg if {
 	input.resource.google_compute_network
 	network := input.resource.google_compute_network[_]
 

--- a/policy/terraform/gcp/gce/deny_compute_network_auto_create_subnets_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_network_auto_create_subnets_test.rego
@@ -1,40 +1,32 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_network_auto_create_subnets {
-	input := {
-		"resource": {
-			"google_compute_network": {
-				"deny-1": {
-					"name": "deny-me-1",
-				},
-				"deny-2": {
-					"name": "deny-me-2",
-				    "auto_create_subnetworks": true,
-				}
-			},
-		}
-	}
+test_deny_compute_network_auto_create_subnets if {
+	inp := {"resource": {"google_compute_network": {
+		"deny-1": {"name": "deny-me-1"},
+		"deny-2": {
+			"name": "deny-me-2",
+			"auto_create_subnetworks": true,
+		},
+	}}}
 
-	t.error_count(deny_compute_network_auto_create_subnets, 2) with input as input
+	t.error_count(deny_compute_network_auto_create_subnets, 2) with input as inp
 }
 
-test_allow_compute_network_auto_create_subnets_disabled {
-	input := {
-		"resource": {
-			"google_compute_network": {
-				"valid": {
-				    "name": "valid",
-				    "auto_create_subnetworks": false,
-				},
-				"excepted": {
-					"//": "TF_GCP_42",
-				    "name": "excepted",
-				}
-			},
-		}
-	}
+test_allow_compute_network_auto_create_subnets_disabled if {
+	inp := {"resource": {"google_compute_network": {
+		"valid": {
+			"name": "valid",
+			"auto_create_subnetworks": false,
+		},
+		"excepted": {
+			"//": "TF_GCP_42",
+			"name": "excepted",
+		},
+	}}}
 
-	t.no_errors(deny_compute_network_auto_create_subnets) with input as input
+	t.no_errors(deny_compute_network_auto_create_subnets) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_project_metadata_ssh_keys.rego
+++ b/policy/terraform/gcp/gce/deny_compute_project_metadata_ssh_keys.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check40 := "TF_GCP_40"
 
 # DENY(TF_GCP_40)
-deny_compute_project_metadata_ssh_keys[msg] {
+deny_compute_project_metadata_ssh_keys contains msg if {
 	input.resource.google_compute_project_metadata
 	project_meta := input.resource.google_compute_project_metadata[name]
 
@@ -18,7 +20,7 @@ deny_compute_project_metadata_ssh_keys[msg] {
 	msg = sprintf("%s: compute project metadata: %s wants to set project-wide ssh keys. More info: %s", [check40, name, l.get_url(check40)])
 }
 
-deny_compute_project_metadata_item_ssh_keys[msg] {
+deny_compute_project_metadata_item_ssh_keys contains msg if {
 	input.resource.google_compute_project_metadata_item
 	project_meta_item := input.resource.google_compute_project_metadata_item[name]
 

--- a/policy/terraform/gcp/gce/deny_compute_project_metadata_ssh_keys_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_project_metadata_ssh_keys_test.rego
@@ -1,51 +1,35 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_project_metadata_ssh_keys {
-	input := {
-		"resource": {
-			"google_compute_project_metadata": {
-				"default": {
-  	  	  	  	  	  "metadata": {
-    					"ssh-keys": "bar",
-  	  	  	  	  	  }
-				}
-			},
-			"google_compute_project_metadata_item": {
-				"default": {
-  	  	  	  	  	"key": "ssh-keys",
-  	  	  	  	  	"value": "bar",
-				}
-			}
-		}
-	}
+test_deny_compute_project_metadata_ssh_keys if {
+	inp := {"resource": {
+		"google_compute_project_metadata": {"default": {"metadata": {"ssh-keys": "bar"}}},
+		"google_compute_project_metadata_item": {"default": {
+			"key": "ssh-keys",
+			"value": "bar",
+		}},
+	}}
 
-	t.error_count(deny_compute_project_metadata_ssh_keys, 1) with input as input
-	t.error_count(deny_compute_project_metadata_item_ssh_keys, 1) with input as input
+	t.error_count(deny_compute_project_metadata_ssh_keys, 1) with input as inp
+	t.error_count(deny_compute_project_metadata_item_ssh_keys, 1) with input as inp
 }
 
-test_allow_compute_project_metadata_ssh_keys_excepted {
-	input := {
-		"resource": {
-			"google_compute_project_metadata": {
-				"default": {
-  	  	  	  	  	  "//": "TF_GCP_40",
-  	  	  	  	  	  "metadata": {
-    					"ssh-keys": "bar",
-  	  	  	  	  	  }
-				}
-			},
-			"google_compute_project_metadata_item": {
-				"default": {
-  	  	  	  	  	"//": "TF_GCP_40",
-  	  	  	  	  	"key": "ssh-keys",
-  	  	  	  	  	"value": "bar",
-				}
-			}
-		}
-	}
+test_allow_compute_project_metadata_ssh_keys_excepted if {
+	inp := {"resource": {
+		"google_compute_project_metadata": {"default": {
+			"//": "TF_GCP_40",
+			"metadata": {"ssh-keys": "bar"},
+		}},
+		"google_compute_project_metadata_item": {"default": {
+			"//": "TF_GCP_40",
+			"key": "ssh-keys",
+			"value": "bar",
+		}},
+	}}
 
-	t.no_errors(deny_compute_project_metadata_ssh_keys) with input as input
-	t.no_errors(deny_compute_project_metadata_item_ssh_keys) with input as input
+	t.no_errors(deny_compute_project_metadata_ssh_keys) with input as inp
+	t.no_errors(deny_compute_project_metadata_item_ssh_keys) with input as inp
 }

--- a/policy/terraform/gcp/gce/deny_compute_weak_ssl_policy.rego
+++ b/policy/terraform/gcp/gce/deny_compute_weak_ssl_policy.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check11 := "TF_GCP_11"
 
 # DENY(TF_GCP_11)
-deny_compute_weak_ssl_policy[msg] {
+deny_compute_weak_ssl_policy contains msg if {
 	input.resource.google_compute_ssl_policy
 	p := input.resource.google_compute_ssl_policy[i]
 	not l.contains_element(["MODERN", "RESTRICTED"], p.profile)

--- a/policy/terraform/gcp/gce/deny_compute_weak_ssl_policy_test.rego
+++ b/policy/terraform/gcp/gce/deny_compute_weak_ssl_policy_test.rego
@@ -1,62 +1,48 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_compute_weak_ssl_policy {
-    input := {
-        "resource": {
-            "google_compute_ssl_policy": {
-                "p1": {
-                    "name": "p1",
-                    "profile": "COMPATIBLE",
-                }
-            }
-        }
-    }
+test_deny_compute_weak_ssl_policy if {
+	inp := {"resource": {"google_compute_ssl_policy": {"p1": {
+		"name": "p1",
+		"profile": "COMPATIBLE",
+	}}}}
 
-    t.error_count(deny_compute_weak_ssl_policy, 1) with input as input
+	t.error_count(deny_compute_weak_ssl_policy, 1) with input as inp
 }
 
-test_not_deny_compute_weak_ssl_policy_when_exception {
-    input := {
-        "resource": {
-            "google_compute_ssl_policy": {
-                "p1": {
-                    "//": "TF_GCP_11",
-                    "name": "p1",
-                    "profile": "COMPATIBLE"
-                }
-            }
-        }
-    }
+test_not_deny_compute_weak_ssl_policy_when_exception if {
+	inp := {"resource": {"google_compute_ssl_policy": {"p1": {
+		"//": "TF_GCP_11",
+		"name": "p1",
+		"profile": "COMPATIBLE",
+	}}}}
 
-    t.no_errors(deny_compute_weak_ssl_policy) with input as input
+	t.no_errors(deny_compute_weak_ssl_policy) with input as inp
 }
 
-test_deny_compute_weak_ssl_policy_multiple {
-    input := {
-        "resource": {
-            "google_compute_ssl_policy": {
-                "compatible": {
-                    "//": "TF_GCP_11",
-                    "name": "p1",
-                    "profile": "COMPATIBLE"
-                },
-                "compatible2": {
-                   	"name": "p2",
-                    "profile": "COMPATIBLE"
-                },
-                "modern": {
-                    "name": "p3",
-                    "profile": "MODERN"
-                },
-                "restricted": {
-                    "name": "p3",
-                    "profile": "RESTRICTED"
-                }
-            }
-        }
-    }
+test_deny_compute_weak_ssl_policy_multiple if {
+	inp := {"resource": {"google_compute_ssl_policy": {
+		"compatible": {
+			"//": "TF_GCP_11",
+			"name": "p1",
+			"profile": "COMPATIBLE",
+		},
+		"compatible2": {
+			"name": "p2",
+			"profile": "COMPATIBLE",
+		},
+		"modern": {
+			"name": "p3",
+			"profile": "MODERN",
+		},
+		"restricted": {
+			"name": "p3",
+			"profile": "RESTRICTED",
+		},
+	}}}
 
-    t.error_count(deny_compute_weak_ssl_policy, 1) with input as input
+	t.error_count(deny_compute_weak_ssl_policy, 1) with input as inp
 }

--- a/policy/terraform/gcp/gcs/deny_bucket_public_iam_binding.rego
+++ b/policy/terraform/gcp/gcs/deny_bucket_public_iam_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check03 := "TF_GCP_03"
 
 # DENY(TF_GCP_03)
-deny_public_iam_binding[msg] {
+deny_public_iam_binding contains msg if {
 	input.resource.google_storage_bucket_iam_binding
 	binding := input.resource.google_storage_bucket_iam_binding[k]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/gcs/deny_bucket_public_iam_binding_test.rego
+++ b/policy/terraform/gcp/gcs/deny_bucket_public_iam_binding_test.rego
@@ -1,63 +1,49 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_public_iam_member {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_binding": {
-                "public-member": {
-                    "bucket": "a bucket",
-                    "role": "roles/storage.admin",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_public_iam_member if {
+	inp := {"resource": {"google_storage_bucket_iam_binding": {"public-member": {
+		"bucket": "a bucket",
+		"role": "roles/storage.admin",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.error_count(deny_public_iam_binding, 1) with input as input
+	t.error_count(deny_public_iam_binding, 1) with input as inp
 }
 
-test_not_deny_public_iam_member_when_exception {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_03",
-                    "bucket": "embark-public",
-                    "role": "roles/storage.admin",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_not_deny_public_iam_member_when_exception if {
+	inp := {"resource": {"google_storage_bucket_iam_binding": {"public-member": {
+		"//": "TF_GCP_03",
+		"bucket": "embark-public",
+		"role": "roles/storage.admin",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.no_errors(deny_public_iam_binding) with input as input
+	t.no_errors(deny_public_iam_binding) with input as inp
 }
 
-test_deny_public_iam_member_more_members {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_03",
-                    "bucket": "embark-public",
-                    "role": "roles/storage.admin",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should be blocked": {
-                    "bucket": "a bucket",
-                    "role": "roles/storage.admin",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should not be blocked": {
-                    "bucket": "a bucket",
-                    "role": "roles/storage.admin",
-                    "members": ["group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_public_iam_member_more_members if {
+	inp := {"resource": {"google_storage_bucket_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_03",
+			"bucket": "embark-public",
+			"role": "roles/storage.admin",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should be blocked": {
+			"bucket": "a bucket",
+			"role": "roles/storage.admin",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should not be blocked": {
+			"bucket": "a bucket",
+			"role": "roles/storage.admin",
+			"members": ["group:test@embark.dev"],
+		},
+	}}}
 
-    t.error_count(deny_public_iam_binding, 1) with input as input
+	t.error_count(deny_public_iam_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/gcs/deny_bucket_public_iam_member.rego
+++ b/policy/terraform/gcp/gcs/deny_bucket_public_iam_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check02 := "TF_GCP_02"
 
 # DENY(TF_GCP_02)
-deny_bucket_public_iam_member[msg] {
+deny_bucket_public_iam_member contains msg if {
 	input.resource.google_storage_bucket_iam_member
 	member := input.resource.google_storage_bucket_iam_member[k]
 	l.contains_element(blacklisted_users, member.member)

--- a/policy/terraform/gcp/gcs/deny_bucket_public_iam_member_test.rego
+++ b/policy/terraform/gcp/gcs/deny_bucket_public_iam_member_test.rego
@@ -1,58 +1,44 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_bucket_public_iam_member {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_member": {
-                "public-member": {
-                    "bucket": "a bucket",
-                    "role": "roles/storage.admin",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_bucket_public_iam_member if {
+	inp := {"resource": {"google_storage_bucket_iam_member": {"public-member": {
+		"bucket": "a bucket",
+		"role": "roles/storage.admin",
+		"member": "allUsers",
+	}}}}
 
-    t.error_count(deny_bucket_public_iam_member, 1) with input as input
+	t.error_count(deny_bucket_public_iam_member, 1) with input as inp
 }
 
-test_not_deny_bucket_public_iam_member_when_exception {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_02",
-                    "bucket": "embark-public",
-                    "role": "roles/storage.admin",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_not_deny_bucket_public_iam_member_when_exception if {
+	inp := {"resource": {"google_storage_bucket_iam_member": {"public-member": {
+		"//": "TF_GCP_02",
+		"bucket": "embark-public",
+		"role": "roles/storage.admin",
+		"member": "allUsers",
+	}}}}
 
-    t.no_errors(deny_bucket_public_iam_member) with input as input
+	t.no_errors(deny_bucket_public_iam_member) with input as inp
 }
 
-test_deny_bucket_public_iam_member_more_members {
-    input := {
-        "resource": {
-            "google_storage_bucket_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_02",
-                    "bucket": "embark-public",
-                    "role": "roles/storage.admin",
-                    "member": "allUsers"
-                },
-                "should be blocked": {
-                    "bucket": "a bucket",
-                    "role": "roles/storage.admin",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_bucket_public_iam_member_more_members if {
+	inp := {"resource": {"google_storage_bucket_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_02",
+			"bucket": "embark-public",
+			"role": "roles/storage.admin",
+			"member": "allUsers",
+		},
+		"should be blocked": {
+			"bucket": "a bucket",
+			"role": "roles/storage.admin",
+			"member": "allUsers",
+		},
+	}}}
 
-    t.error_count(deny_bucket_public_iam_member, 1) with input as input
+	t.error_count(deny_bucket_public_iam_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/gcs/deny_non_uniform_bucket_level_access.rego
+++ b/policy/terraform/gcp/gcs/deny_non_uniform_bucket_level_access.rego
@@ -1,11 +1,13 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check01 := "TF_GCP_01"
 
-deny_non_uniform_level_access[msg] {
+deny_non_uniform_level_access contains msg if {
 	input.resource.google_storage_bucket
 	bucket := input.resource.google_storage_bucket[k]
 	not make_exception(check01, bucket)

--- a/policy/terraform/gcp/gcs/deny_non_uniform_bucket_level_access_test.rego
+++ b/policy/terraform/gcp/gcs/deny_non_uniform_bucket_level_access_test.rego
@@ -1,75 +1,62 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_uniform_level_access_exception {
-    input := {
-        "resource": {
-            "google_storage_bucket": {
-                "b3": {
-                    "name": "b3",
-                    "//": "TF_GCP_01",
-                    "uniform_bucket_level_access": false,
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                }
-            }
-        }
-    }
+test_deny_uniform_level_access_exception if {
+	inp := {"resource": {"google_storage_bucket": {"b3": {
+		"name": "b3",
+		"//": "TF_GCP_01",
+		"uniform_bucket_level_access": false,
+		"location": "eu",
+		"storage_class": "STANDARD",
+	}}}}
 
-    t.no_errors(deny_non_uniform_level_access) with input as input
+	t.no_errors(deny_non_uniform_level_access) with input as inp
 }
 
-test_deny_uniform_level_access {
-    input := {
-        "resource": {
-            "google_storage_bucket": {
-                "b1": {
-                    "name": "b1",
-                    "uniform_bucket_level_access": true,
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                },
-                "b2": {
-                    "name": "b2",
-                    "uniform_bucket_level_access": "false",
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                },
-            }
-        }
-    }
+test_deny_uniform_level_access if {
+	inp := {"resource": {"google_storage_bucket": {
+		"b1": {
+			"name": "b1",
+			"uniform_bucket_level_access": true,
+			"location": "eu",
+			"storage_class": "STANDARD",
+		},
+		"b2": {
+			"name": "b2",
+			"uniform_bucket_level_access": "false",
+			"location": "eu",
+			"storage_class": "STANDARD",
+		},
+	}}}
 
-    t.error_count(deny_non_uniform_level_access, 1) with input as input
+	t.error_count(deny_non_uniform_level_access, 1) with input as inp
 }
 
-test_deny_uniform_level_access_all {
-    input := {
-        "resource": {
-            "google_storage_bucket": {
-                "b1": {
-                    "name": "b1",
-                    "uniform_bucket_level_access": true,
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                },
-                "b2": {
-                    "name": "b2",
-                    "uniform_bucket_level_access": false,
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                },
-                "b3": {
-                    "name": "b3",
-                    "//": "TF_GCP_01",
-                    "uniform_bucket_level_access": false,
-                    "location": "eu",
-                    "storage_class": "STANDARD"
-                }
-            }
-        }
-    }
+test_deny_uniform_level_access_all if {
+	inp := {"resource": {"google_storage_bucket": {
+		"b1": {
+			"name": "b1",
+			"uniform_bucket_level_access": true,
+			"location": "eu",
+			"storage_class": "STANDARD",
+		},
+		"b2": {
+			"name": "b2",
+			"uniform_bucket_level_access": false,
+			"location": "eu",
+			"storage_class": "STANDARD",
+		},
+		"b3": {
+			"name": "b3",
+			"//": "TF_GCP_01",
+			"uniform_bucket_level_access": false,
+			"location": "eu",
+			"storage_class": "STANDARD",
+		},
+	}}}
 
-    t.error_count(deny_non_uniform_level_access, 1) with input as input
+	t.error_count(deny_non_uniform_level_access, 1) with input as inp
 }
-

--- a/policy/terraform/gcp/gke/deny_gke_alias_ip.rego
+++ b/policy/terraform/gcp/gke/deny_gke_alias_ip.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check05 := "TF_GCP_05"
 
 # DENY(TF_GCP_05) - google_container_cluster
-deny_gke_alias_ip[msg] {
+deny_gke_alias_ip contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[i]
 	not input.resource.google_container_cluster[i].ip_allocation_policy

--- a/policy/terraform/gcp/gke/deny_gke_alias_ip_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_alias_ip_test.rego
@@ -1,53 +1,37 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_google_container_cluster {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "ip_allocation_policy": {
-                        "cluster_secondary_range_name": "pod-range",
-                        "services_secondary_range_name": "service-range"
-                    }
-                }
-            }
-        },
-    }
+test_not_deny_google_container_cluster if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"ip_allocation_policy": {
+			"cluster_secondary_range_name": "pod-range",
+			"services_secondary_range_name": "service-range",
+		},
+	}}}}
 
-    t.no_errors(deny_gke_alias_ip) with input as input
+	t.no_errors(deny_gke_alias_ip) with input as inp
 }
 
-test_not_deny_google_container_cluster_with_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_05" 
-                }
-            }
-        },
-    }
+test_not_deny_google_container_cluster_with_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_05",
+	}}}}
 
-    t.no_errors(deny_gke_alias_ip) with input as input
+	t.no_errors(deny_gke_alias_ip) with input as inp
 }
 
-test_deny_google_container_cluster {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                }
-            }
-        },
-    }
+test_deny_google_container_cluster if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+	}}}}
 
-    t.error_count(deny_gke_alias_ip, 1) with input as input
+	t.error_count(deny_gke_alias_ip, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_autorepair.rego
+++ b/policy/terraform/gcp/gke/deny_gke_autorepair.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check21 := "TF_GCP_21"
 
-gke_autorepair_disabled(node_pool) {
+gke_autorepair_disabled(node_pool) if {
 	not node_pool.management.auto_repair
-} else {
+} else if {
 	l.is_false(node_pool.management.auto_repair)
 }
 
 # DENY(TF_GCP_21) - google_container_node_pool
-deny_gke_autorepair_disabled[msg] {
+deny_gke_autorepair_disabled contains msg if {
 	input.resource.google_container_node_pool
 	node_pool := input.resource.google_container_node_pool[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_autorepair_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_autorepair_test.rego
@@ -1,94 +1,60 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_autorepair {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_repair": true            
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_autorepair if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_repair": true},
+	}}}}
 
-    t.no_errors(deny_gke_autorepair_disabled) with input as input
+	t.no_errors(deny_gke_autorepair_disabled) with input as inp
 }
 
-test_not_deny_autorepair_exclusions {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_21" 
-                }
-            }
-        }
-    }
+test_not_deny_autorepair_exclusions if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_21",
+	}}}}
 
-    t.no_errors(deny_gke_autorepair_disabled) with input as input
+	t.no_errors(deny_gke_autorepair_disabled) with input as inp
 }
 
-test_deny_missing_autorepair_config {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {}
-                }           
-            }
-        }
-    }
+test_deny_missing_autorepair_config if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {},
+	}}}}
 
-    t.error_count(deny_gke_autorepair_disabled, 1) with input as input
+	t.error_count(deny_gke_autorepair_disabled, 1) with input as inp
 }
 
-test_deny_autorepair_false {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_repair": false           
-                    }
-                }
-            }
-        }
-    }
+test_deny_autorepair_false if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_repair": false},
+	}}}}
 
-    t.error_count(deny_gke_autorepair_disabled, 1) with input as input
+	t.error_count(deny_gke_autorepair_disabled, 1) with input as inp
 }
 
-test_deny_autorepair_false_string {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_repair": "false"           
-                    }
-                }
-            }
-        }
-    }
+test_deny_autorepair_false_string if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_repair": "false"},
+	}}}}
 
-    t.error_count(deny_gke_autorepair_disabled, 1) with input as input
+	t.error_count(deny_gke_autorepair_disabled, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_autoupgrade_disabled.rego
+++ b/policy/terraform/gcp/gke/deny_gke_autoupgrade_disabled.rego
@@ -1,19 +1,21 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check19 := "TF_GCP_19"
 
-gke_autoupgrade_disabled(node_pool) {
+gke_autoupgrade_disabled(node_pool) if {
 	not node_pool.management.auto_upgrade
-} else {
+} else if {
 	au := node_pool.management.auto_upgrade
 	l.is_false(au)
 }
 
 # DENY(TF_GCP_19) - google_container_node_pool
-deny_gke_autoupgrade_disabled[msg] {
+deny_gke_autoupgrade_disabled contains msg if {
 	input.resource.google_container_node_pool
 	node_pool := input.resource.google_container_node_pool[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_autoupgrade_disabled_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_autoupgrade_disabled_test.rego
@@ -1,94 +1,60 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_autoupgrade {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_upgrade": true            
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_autoupgrade if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_upgrade": true},
+	}}}}
 
-    t.no_errors(deny_gke_autoupgrade_disabled) with input as input
+	t.no_errors(deny_gke_autoupgrade_disabled) with input as inp
 }
 
-test_not_deny_autoupgrade_exclusions {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_19" 
-                }
-            }
-        }
-    }
+test_not_deny_autoupgrade_exclusions if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_19",
+	}}}}
 
-    t.no_errors(deny_gke_autoupgrade_disabled) with input as input
+	t.no_errors(deny_gke_autoupgrade_disabled) with input as inp
 }
 
-test_deny_missing_autoupgrade_config {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {}
-                }           
-            }
-        }
-    }
+test_deny_missing_autoupgrade_config if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {},
+	}}}}
 
-    t.error_count(deny_gke_autoupgrade_disabled, 1) with input as input
+	t.error_count(deny_gke_autoupgrade_disabled, 1) with input as inp
 }
 
-test_deny_autoupgrade_false {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_upgrade": false           
-                    }
-                }
-            }
-        }
-    }
+test_deny_autoupgrade_false if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_upgrade": false},
+	}}}}
 
-    t.error_count(deny_gke_autoupgrade_disabled, 1) with input as input
+	t.error_count(deny_gke_autoupgrade_disabled, 1) with input as inp
 }
 
-test_deny_autoupgrade_false_string {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "management": {
-                        "auto_upgrade": "false"           
-                    }
-                }
-            }
-        }
-    }
+test_deny_autoupgrade_false_string if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"management": {"auto_upgrade": "false"},
+	}}}}
 
-    t.error_count(deny_gke_autoupgrade_disabled, 1) with input as input
+	t.error_count(deny_gke_autoupgrade_disabled, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_imagetype.rego
+++ b/policy/terraform/gcp/gke/deny_gke_imagetype.rego
@@ -1,5 +1,7 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
@@ -7,17 +9,17 @@ check27 := "TF_GCP_27"
 
 allowed_image_types := {"cos", "cos_containerd"}
 
-gke_imagetype(node_pool) {
+gke_imagetype(node_pool) if {
 	not node_pool.node_config.image_type
-} else {
+} else if {
 	not is_string(node_pool.node_config.image_type)
-} else {
+} else if {
 	image_type := node_pool.node_config.image_type
 	not l.contains_element(allowed_image_types, lower(image_type))
 }
 
 # DENY(TF_GCP_27) - google_container_node_pool
-deny_gke_imagetype[msg] {
+deny_gke_imagetype contains msg if {
 	input.resource.google_container_node_pool
 	node_pool := input.resource.google_container_node_pool[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_imagetype_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_imagetype_test.rego
@@ -1,94 +1,63 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_imagetype {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "cos": {
-                    "name": "cos",
-                    "cluster": "cluster1",
-                    "location": "us-central1",
-                    "node_config": {
-                        "image_type": "cos",
-                    }
-                },
-                "cos_containerd": {
-                    "name": "cos_containerd",
-                    "cluster": "cluster1",
-                    "location": "us-central1",
-                    "node_config": {
-                        "image_type": "cos_containerd",
-                    }
-                },
-                "test_case_insensitive": {
-                    "name": "test_case_insensitive",
-                    "cluster": "cluster1",
-                    "location": "us-central1",
-                    "node_config": {
-                        "image_type": "cOs_CoNtAiNeRd",
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_imagetype if {
+	inp := {"resource": {"google_container_node_pool": {
+		"cos": {
+			"name": "cos",
+			"cluster": "cluster1",
+			"location": "us-central1",
+			"node_config": {"image_type": "cos"},
+		},
+		"cos_containerd": {
+			"name": "cos_containerd",
+			"cluster": "cluster1",
+			"location": "us-central1",
+			"node_config": {"image_type": "cos_containerd"},
+		},
+		"test_case_insensitive": {
+			"name": "test_case_insensitive",
+			"cluster": "cluster1",
+			"location": "us-central1",
+			"node_config": {"image_type": "cOs_CoNtAiNeRd"},
+		},
+	}}}
 
-    t.no_errors(deny_gke_imagetype) with input as input
+	t.no_errors(deny_gke_imagetype) with input as inp
 }
 
-test_not_deny_imagetype_exclusions {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "name": "test",
-                    "cluster": "cluster1",
-                    "location": "us-central1",
-                    "//": "TF_GCP_27" 
-                }
-            }
-        }
-    }
+test_not_deny_imagetype_exclusions if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"name": "test",
+		"cluster": "cluster1",
+		"location": "us-central1",
+		"//": "TF_GCP_27",
+	}}}}
 
-    t.no_errors(deny_gke_imagetype) with input as input
+	t.no_errors(deny_gke_imagetype) with input as inp
 }
 
-test_deny_missing_imagetype_config {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "name": "test",
-                    "cluster": "cluster1",                    
-                    "location": "us-central1",
-                    "node_config": {
-                        "image_type": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_imagetype_config if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"name": "test",
+		"cluster": "cluster1",
+		"location": "us-central1",
+		"node_config": {"image_type": {}},
+	}}}}
 
-    t.error_count(deny_gke_imagetype, 1) with input as input
+	t.error_count(deny_gke_imagetype, 1) with input as inp
 }
 
-test_deny_imagetype_wrong {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "name": "test",
-                    "cluster": "cluster1",
-                    "location": "us-central1",
-                    "node_config": {
-                        "image_type": "UBUNTU"
-                    }
-                }
-            }
-        }
-    }
+test_deny_imagetype_wrong if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"name": "test",
+		"cluster": "cluster1",
+		"location": "us-central1",
+		"node_config": {"image_type": "UBUNTU"},
+	}}}}
 
-    t.error_count(deny_gke_imagetype, 1) with input as input
+	t.error_count(deny_gke_imagetype, 1) with input as inp
 }
-

--- a/policy/terraform/gcp/gke/deny_gke_integrity_monitoring_masters.rego
+++ b/policy/terraform/gcp/gke/deny_gke_integrity_monitoring_masters.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check32 := "TF_GCP_32"
 
-gke_integrity_monitoring_masters_disabled(cluster) {
+gke_integrity_monitoring_masters_disabled(cluster) if {
 	not cluster.node_config.shielded_instance_config.enable_integrity_monitoring
-} else {
+} else if {
 	l.is_false(cluster.node_config.shielded_instance_config.enable_integrity_monitoring)
 }
 
 # DENY(TF_GCP_32) - google_container_cluster
-deny_gke_integrity_monitoring_masters_disabled[msg] {
+deny_gke_integrity_monitoring_masters_disabled contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_integrity_monitoring_masters_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_integrity_monitoring_masters_test.rego
@@ -1,97 +1,55 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_integrity_monitoring_masters {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_integrity_monitoring": true
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_integrity_monitoring_masters if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_integrity_monitoring": true}},
+	}}}}
 
-    t.no_errors(deny_gke_integrity_monitoring_masters_disabled) with input as input
+	t.no_errors(deny_gke_integrity_monitoring_masters_disabled) with input as inp
 }
 
-test_not_deny_integrity_monitoring_masters_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_32" 
-                }
-            }
-        }
-    }
+test_not_deny_integrity_monitoring_masters_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_32",
+	}}}}
 
-    t.no_errors(deny_gke_integrity_monitoring_masters_disabled) with input as input
+	t.no_errors(deny_gke_integrity_monitoring_masters_disabled) with input as inp
 }
 
-test_deny_missing_integrity_monitoring_masters_config {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_integrity_monitoring_masters_config if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {}},
+	}}}}
 
-    t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as inp
 }
 
-test_deny_integrity_monitoring_masters_false {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_integrity_monitoring": false
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_integrity_monitoring_masters_false if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_integrity_monitoring": false}},
+	}}}}
 
-    t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as inp
 }
 
-test_deny_integrity_monitoring_masters_false_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_integrity_monitoring": "false"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_integrity_monitoring_masters_false_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_integrity_monitoring": "false"}},
+	}}}}
 
-    t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_integrity_monitoring_masters_disabled, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_legacy_abac.rego
+++ b/policy/terraform/gcp/gke/deny_gke_legacy_abac.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check45 := "TF_GCP_45"
 
 # DENY(TF_GCP_45) - google_container_cluster
-deny_gke_legacy_abac[msg] {
+deny_gke_legacy_abac contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_legacy_abac_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_legacy_abac_test.rego
@@ -1,99 +1,65 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_legacy_abac_false {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_legacy_abac": false
-                }
-            }
-        }
-    }
+test_not_deny_legacy_abac_false if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_legacy_abac": false,
+	}}}}
 
-    t.no_errors(deny_gke_legacy_abac) with input as input
+	t.no_errors(deny_gke_legacy_abac) with input as inp
 }
 
-test_not_deny_legacy_abac_false_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_legacy_abac": "false"
-                }
-            }
-        }
-    }
+test_not_deny_legacy_abac_false_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_legacy_abac": "false",
+	}}}}
 
-    t.no_errors(deny_gke_legacy_abac) with input as input
+	t.no_errors(deny_gke_legacy_abac) with input as inp
 }
 
-test_not_deny_legacy_abac_missing {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                }
-            }
-        }
-    }
+test_not_deny_legacy_abac_missing if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+	}}}}
 
-    t.no_errors(deny_gke_legacy_abac) with input as input
+	t.no_errors(deny_gke_legacy_abac) with input as inp
 }
 
-test_not_deny_legacy_abac_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_45",
-                    "enable_legacy_abac": "true"
-                }
-            }
-        }
-    }
+test_not_deny_legacy_abac_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_45",
+		"enable_legacy_abac": "true",
+	}}}}
 
-    t.no_errors(deny_gke_legacy_abac) with input as input
+	t.no_errors(deny_gke_legacy_abac) with input as inp
 }
 
-test_deny_legacy_abac_true {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_legacy_abac": true
-                }
-            }
-        }
-    }
+test_deny_legacy_abac_true if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_legacy_abac": true,
+	}}}}
 
-    t.error_count(deny_gke_legacy_abac, 1) with input as input
+	t.error_count(deny_gke_legacy_abac, 1) with input as inp
 }
 
-test_deny_gke_legacy_abac_true_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_legacy_abac": "true"
-                }
-            }
-        }
-    }
+test_deny_gke_legacy_abac_true_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_legacy_abac": "true",
+	}}}}
 
-    t.error_count(deny_gke_legacy_abac, 1) with input as input
+	t.error_count(deny_gke_legacy_abac, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_nodes_default_service_account.rego
+++ b/policy/terraform/gcp/gke/deny_gke_nodes_default_service_account.rego
@@ -1,17 +1,19 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
-check41 = "TF_GCP_41"
+check41 := "TF_GCP_41"
 
-nodes_using_default_svc_acc(gke) {
+nodes_using_default_svc_acc(gke) if {
 	not gke.node_config.service_account
-} else {
+} else if {
 	regex.match(default_service_account_regexp, gke.node_config.service_account)
 }
 
-deny_gke_node_pool_nodes_default_service_account[msg] {
+deny_gke_node_pool_nodes_default_service_account contains msg if {
 	input.resource.google_container_node_pool
 
 	node_pool := input.resource.google_container_node_pool[_]

--- a/policy/terraform/gcp/gke/deny_gke_nodes_default_service_account_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_nodes_default_service_account_test.rego
@@ -1,51 +1,39 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_gke_node_pool_nodes_default_service_account {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "not-defined": {
-                    "name": "not-defined",
-                    "location": "us-central1",
-                },
-                "default": {
-                    "name": "default",
-                    "location": "us-central1",
-                    "node_config": {
-                        "service_account": "000000000000-compute@developer.gserviceaccount.com"
-                    }
-                }
-            }
-        }
-    }
+test_deny_gke_node_pool_nodes_default_service_account if {
+	inp := {"resource": {"google_container_node_pool": {
+		"not-defined": {
+			"name": "not-defined",
+			"location": "us-central1",
+		},
+		"default": {
+			"name": "default",
+			"location": "us-central1",
+			"node_config": {"service_account": "000000000000-compute@developer.gserviceaccount.com"},
+		},
+	}}}
 
-    t.error_count(deny_gke_node_pool_nodes_default_service_account, 2) with input as input
+	t.error_count(deny_gke_node_pool_nodes_default_service_account, 2) with input as inp
 }
 
-test_allow_valid_gke_node_pool_nodes_service_account {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "valid": {
-                    "name": "valid",
-                    "location": "us-central1",
-                    "node_config": {
-                        "service_account": "my-service@my-project.iam.gserviceaccount.com"
-                    }
-                },
-                "excepted": {
-                    "name": "excepted",
-                    "location": "us-central1",
-                    "//": "TF_GCP_41",
-                    "node_config": {
-                        "service_account": "000000000000-compute@developer.gserviceaccount.com"
-                    }
-                }
-            }
-        }
-    }
+test_allow_valid_gke_node_pool_nodes_service_account if {
+	inp := {"resource": {"google_container_node_pool": {
+		"valid": {
+			"name": "valid",
+			"location": "us-central1",
+			"node_config": {"service_account": "my-service@my-project.iam.gserviceaccount.com"},
+		},
+		"excepted": {
+			"name": "excepted",
+			"location": "us-central1",
+			"//": "TF_GCP_41",
+			"node_config": {"service_account": "000000000000-compute@developer.gserviceaccount.com"},
+		},
+	}}}
 
-    t.no_errors(deny_gke_node_pool_nodes_default_service_account) with input as input
+	t.no_errors(deny_gke_node_pool_nodes_default_service_account) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_releasechannel.rego
+++ b/policy/terraform/gcp/gke/deny_gke_releasechannel.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check26 := "TF_GCP_26"
 
-gke_releasechannel_disabled(cluster) {
+gke_releasechannel_disabled(cluster) if {
 	not cluster.release_channel.channel
-} else {
+} else if {
 	cluster.release_channel.channel != "REGULAR"
 }
 
 # DENY(TF_GCP_26) - google_container_cluster
-deny_gke_releasechannel_disabled[msg] {
+deny_gke_releasechannel_disabled contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_releasechannel_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_releasechannel_test.rego
@@ -1,74 +1,45 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_releasechannel {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "release_channel": {                        
-                          "channel": "REGULAR"                        
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_releasechannel if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"release_channel": {"channel": "REGULAR"},
+	}}}}
 
-    t.no_errors(deny_gke_releasechannel_disabled) with input as input
+	t.no_errors(deny_gke_releasechannel_disabled) with input as inp
 }
 
-test_not_deny_releasechannel_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_26" 
-                }
-            }
-        }
-    }
+test_not_deny_releasechannel_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_26",
+	}}}}
 
-    t.no_errors(deny_gke_releasechannel_disabled) with input as input
+	t.no_errors(deny_gke_releasechannel_disabled) with input as inp
 }
 
-test_deny_missing_releasechannel_config {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "release_channel": {                        
-                          "channel": {}                     
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_releasechannel_config if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"release_channel": {"channel": {}},
+	}}}}
 
-    t.error_count(deny_gke_releasechannel_disabled, 1) with input as input
+	t.error_count(deny_gke_releasechannel_disabled, 1) with input as inp
 }
 
-test_deny_releasechannel_wrong {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "release_channel": {                        
-                          "channel": "RAPID"                        
-                    }
-                }
-            }
-        }
-    }
+test_deny_releasechannel_wrong if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"release_channel": {"channel": "RAPID"},
+	}}}}
 
-    t.error_count(deny_gke_releasechannel_disabled, 1) with input as input
+	t.error_count(deny_gke_releasechannel_disabled, 1) with input as inp
 }
-

--- a/policy/terraform/gcp/gke/deny_gke_remove_default_pool.rego
+++ b/policy/terraform/gcp/gke/deny_gke_remove_default_pool.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check29 := "TF_GCP_29"
 
-gke_remove_default_node_pool(cluster) {
+gke_remove_default_node_pool(cluster) if {
 	not cluster.remove_default_node_pool
-} else {
+} else if {
 	l.is_false(cluster.remove_default_node_pool)
 }
 
 # DENY(TF_GCP_29) - google_container_cluster
-deny_gke_remove_default_node_pool[msg] {
+deny_gke_remove_default_node_pool contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_remove_default_pool_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_remove_default_pool_test.rego
@@ -1,67 +1,45 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_remove_default_node_pool {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "remove_default_node_pool": true
-                }
-            }
-        }
-    }
+test_not_deny_remove_default_node_pool if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"remove_default_node_pool": true,
+	}}}}
 
-    t.no_errors(deny_gke_remove_default_node_pool) with input as input
+	t.no_errors(deny_gke_remove_default_node_pool) with input as inp
 }
 
-test_not_deny_remove_default_node_pool_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_29" 
-                }
-            }
-        }
-    }
+test_not_deny_remove_default_node_pool_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_29",
+	}}}}
 
-    t.no_errors(deny_gke_remove_default_node_pool) with input as input
+	t.no_errors(deny_gke_remove_default_node_pool) with input as inp
 }
 
-test_deny_remove_default_node_pool_false {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "remove_default_node_pool": false
-                }
-            }
-        }
-    }
+test_deny_remove_default_node_pool_false if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"remove_default_node_pool": false,
+	}}}}
 
-    t.error_count(deny_gke_remove_default_node_pool, 1) with input as input
+	t.error_count(deny_gke_remove_default_node_pool, 1) with input as inp
 }
 
-test_deny_remove_default_node_pool_false_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "remove_default_node_pool": "false"
-                }
-            }
-        }
-    }
+test_deny_remove_default_node_pool_false_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"remove_default_node_pool": "false",
+	}}}}
 
-    t.error_count(deny_gke_remove_default_node_pool, 1) with input as input
+	t.error_count(deny_gke_remove_default_node_pool, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_secure_boot_masters.rego
+++ b/policy/terraform/gcp/gke/deny_gke_secure_boot_masters.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check23 := "TF_GCP_23"
 
-gke_secureboot_masters_disabled(cluster) {
+gke_secureboot_masters_disabled(cluster) if {
 	not cluster.node_config.shielded_instance_config.enable_secure_boot
-} else {
+} else if {
 	l.is_false(cluster.node_config.shielded_instance_config.enable_secure_boot)
 }
 
 # DENY(TF_GCP_23) - google_container_cluster
-deny_gke_secureboot_masters_disabled[msg] {
+deny_gke_secureboot_masters_disabled contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_secure_boot_masters_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_secure_boot_masters_test.rego
@@ -1,97 +1,55 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_secureboot_masters {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": true
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_secureboot_masters if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": true}},
+	}}}}
 
-    t.no_errors(deny_gke_secureboot_masters_disabled) with input as input
+	t.no_errors(deny_gke_secureboot_masters_disabled) with input as inp
 }
 
-test_not_deny_secureboot_masters_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_23" 
-                }
-            }
-        }
-    }
+test_not_deny_secureboot_masters_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_23",
+	}}}}
 
-    t.no_errors(deny_gke_secureboot_masters_disabled) with input as input
+	t.no_errors(deny_gke_secureboot_masters_disabled) with input as inp
 }
 
-test_deny_missing_secureboot_masters_config {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_secureboot_masters_config if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as inp
 }
 
-test_deny_secureboot_masters_false {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": false
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_secureboot_masters_false if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": false}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as inp
 }
 
-test_deny_secureboot_masters_false_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": "false"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_secureboot_masters_false_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": "false"}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_masters_disabled, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_secure_boot_nodes.rego
+++ b/policy/terraform/gcp/gke/deny_gke_secure_boot_nodes.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check22 := "TF_GCP_22"
 
-gke_secureboot_nodes_disabled(node_pool) {
+gke_secureboot_nodes_disabled(node_pool) if {
 	not node_pool.node_config.shielded_instance_config.enable_secure_boot
-} else {
+} else if {
 	l.is_false(node_pool.node_config.shielded_instance_config.enable_secure_boot)
 }
 
 # DENY(TF_GCP_22) - google_container_node_pool
-deny_gke_secureboot_nodes_disabled[msg] {
+deny_gke_secureboot_nodes_disabled contains msg if {
 	input.resource.google_container_node_pool
 	node_pool := input.resource.google_container_node_pool[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_secure_boot_nodes_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_secure_boot_nodes_test.rego
@@ -1,102 +1,60 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_secureboot_nodes {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": true
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_secureboot_nodes if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": true}},
+	}}}}
 
-    t.no_errors(deny_gke_secureboot_nodes_disabled) with input as input
+	t.no_errors(deny_gke_secureboot_nodes_disabled) with input as inp
 }
 
-test_not_deny_secureboot_nodes_exclusions {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_22" 
-                }
-            }
-        }
-    }
+test_not_deny_secureboot_nodes_exclusions if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_22",
+	}}}}
 
-    t.no_errors(deny_gke_secureboot_nodes_disabled) with input as input
+	t.no_errors(deny_gke_secureboot_nodes_disabled) with input as inp
 }
 
-test_deny_missing_secureboot_nodes_config {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_secureboot_nodes_config if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as inp
 }
 
-test_deny_secureboot_nodes_false {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": false
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_secureboot_nodes_false if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": false}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as inp
 }
 
-test_deny_secureboot_nodes_false_string {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster":"cluster1",
-                    "name": "test",
-                    "location": "us-central1",
-                    "node_config": {
-                        "shielded_instance_config": {
-                          "enable_secure_boot": "false"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_secureboot_nodes_false_string if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"location": "us-central1",
+		"node_config": {"shielded_instance_config": {"enable_secure_boot": "false"}},
+	}}}}
 
-    t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as input
+	t.error_count(deny_gke_secureboot_nodes_disabled, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_security_group.rego
+++ b/policy/terraform/gcp/gke/deny_gke_security_group.rego
@@ -1,20 +1,23 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check28 := "TF_GCP_28"
 
-gke_security_group(cluster) {
+gke_security_group(cluster) if {
 	not cluster.authenticator_groups_config.security_group
-} else {
+} else if {
 	not regex.match("gke-security-groups@.*", cluster.authenticator_groups_config.security_group)
 }
 
 # DENY(TF_GCP_28) - google_container_cluster
-deny_gke_security_group[msg] {
+deny_gke_security_group contains msg if {
 	input.resource.google_container_cluster
-	cluster := input.resource.google_container_cluster[_]
+	some c
+	cluster := input.resource.google_container_cluster[c]
 
 	not make_exception(check28, cluster)
 

--- a/policy/terraform/gcp/gke/deny_gke_security_group_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_security_group_test.rego
@@ -1,74 +1,45 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_security_group {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "authenticator_groups_config": {
-                        "security_group": "gke-security-groups@test.com"
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_security_group if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"authenticator_groups_config": {"security_group": "gke-security-groups@test.com"},
+	}}}}
 
-    t.no_errors(deny_gke_security_group) with input as input
+	t.no_errors(deny_gke_security_group) with input as inp
 }
 
-test_not_deny_security_group_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_28" 
-                }
-            }
-        }
-    }
+test_not_deny_security_group_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_28",
+	}}}}
 
-    t.no_errors(deny_gke_security_group) with input as input
+	t.no_errors(deny_gke_security_group) with input as inp
 }
 
-test_deny_missing_security_group_config {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "authenticator_groups_config": {
-                        "security_group": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_security_group_config if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"authenticator_groups_config": {"security_group": ""}
+	}}}}
 
-    t.error_count(deny_gke_security_group, 1) with input as input
+	t.error_count(deny_gke_security_group, 1) with input as inp
 }
 
-test_deny_security_group_wrong {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "authenticator_groups_config": {
-                        "security_group": "something@evilcorp.com"
-                    }
-                }
-            }
-        }
-    }
+test_deny_security_group_wrong if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"authenticator_groups_config": {"security_group": "something@evilcorp.com"}
+	}}}}
 
-    t.error_count(deny_gke_security_group, 1) with input as input
+	t.error_count(deny_gke_security_group, 1) with input as inp
 }
-

--- a/policy/terraform/gcp/gke/deny_gke_shielded_nodes.rego
+++ b/policy/terraform/gcp/gke/deny_gke_shielded_nodes.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check34 := "TF_GCP_34"
 
-gke_shielded_nodes(cluster) {
+gke_shielded_nodes(cluster) if {
 	not cluster.enable_shielded_nodes
-} else {
+} else if {
 	l.is_false(cluster.enable_shielded_nodes)
 }
 
 # DENY(TF_GCP_34) - google_container_cluster
-deny_gke_shielded_nodes[msg] {
+deny_gke_shielded_nodes contains msg if {
 	input.resource.google_container_cluster
 	cluster := input.resource.google_container_cluster[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_shielded_nodes_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_shielded_nodes_test.rego
@@ -1,67 +1,45 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_shielded_nodes {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_shielded_nodes": true
-                }
-            }
-        }
-    }
+test_not_deny_shielded_nodes if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_shielded_nodes": true,
+	}}}}
 
-    t.no_errors(deny_gke_shielded_nodes) with input as input
+	t.no_errors(deny_gke_shielded_nodes) with input as inp
 }
 
-test_not_deny_shielded_nodes_exclusions {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "//": "TF_GCP_34" 
-                }
-            }
-        }
-    }
+test_not_deny_shielded_nodes_exclusions if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"//": "TF_GCP_34",
+	}}}}
 
-    t.no_errors(deny_gke_shielded_nodes) with input as input
+	t.no_errors(deny_gke_shielded_nodes) with input as inp
 }
 
-test_deny_shielded_nodes_false {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_shielded_nodes": false
-                }
-            }
-        }
-    }
+test_deny_shielded_nodes_false if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_shielded_nodes": false,
+	}}}}
 
-    t.error_count(deny_gke_shielded_nodes, 1) with input as input
+	t.error_count(deny_gke_shielded_nodes, 1) with input as inp
 }
 
-test_deny_shielded_nodes_false_string {
-    input := {
-        "resource": {
-            "google_container_cluster": {
-                "test": {
-                    "name": "test",
-                    "location": "us-central1",
-                    "enable_shielded_nodes": "false"
-                }
-            }
-        }
-    }
+test_deny_shielded_nodes_false_string if {
+	inp := {"resource": {"google_container_cluster": {"test": {
+		"name": "test",
+		"location": "us-central1",
+		"enable_shielded_nodes": "false",
+	}}}}
 
-    t.error_count(deny_gke_shielded_nodes, 1) with input as input
+	t.error_count(deny_gke_shielded_nodes, 1) with input as inp
 }

--- a/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes.rego
+++ b/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes.rego
@@ -1,5 +1,7 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
@@ -9,19 +11,19 @@ deprecated_allowed_value := "GKE_METADATA_SERVER"
 
 new_allowed_value := "GKE_METADATA"
 
-gke_workloadidentity_nodes_disabled(node_pool) {
+gke_workloadidentity_nodes_disabled(node_pool) if {
 	node_pool.node_config.workload_metadata_config.mode
 	node_pool.node_config.workload_metadata_config.mode != new_allowed_value
-} else {
+} else if {
 	node_pool.node_config.workload_metadata_config.node_metadata
 	node_pool.node_config.workload_metadata_config.node_metadata != deprecated_allowed_value
-} else {
+} else if {
 	not node_pool.node_config.workload_metadata_config.mode
 	not node_pool.node_config.workload_metadata_config.node_metadata
 }
 
 # DENY(TF_GCP_25) - google_container_node_pool
-deny_gke_workloadidentity_nodes_disabled[msg] {
+deny_gke_workloadidentity_nodes_disabled contains msg if {
 	input.resource.google_container_node_pool
 	node_pool := input.resource.google_container_node_pool[_]
 

--- a/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes_test.rego
+++ b/policy/terraform/gcp/gke/deny_gke_workloadidentity_nodes_test.rego
@@ -1,96 +1,59 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_workloadidentity_nodes {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test1": {
-                    "cluster": "cluster1",              
-                    "name": "test1",
-                    "node_config": {
-                        "workload_metadata_config": {
-                          "node_metadata": "GKE_METADATA_SERVER",
-                        }
-                    }
-                },
-                "test2": {
-                    "cluster": "cluster2",              
-                    "name": "test2",
-                    "node_config": {
-                        "workload_metadata_config": {
-                          "mode": "GKE_METADATA",
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_not_deny_workloadidentity_nodes if {
+	inp := {"resource": {"google_container_node_pool": {
+		"test1": {
+			"cluster": "cluster1",
+			"name": "test1",
+			"node_config": {"workload_metadata_config": {"node_metadata": "GKE_METADATA_SERVER"}},
+		},
+		"test2": {
+			"cluster": "cluster2",
+			"name": "test2",
+			"node_config": {"workload_metadata_config": {"mode": "GKE_METADATA"}},
+		},
+	}}}
 
-    t.no_errors(deny_gke_workloadidentity_nodes_disabled) with input as input
+	t.no_errors(deny_gke_workloadidentity_nodes_disabled) with input as inp
 }
 
-test_not_deny_workloadidentity_nodes_exclusions {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster": "cluster1",                    
-                    "name": "test",
-                    "//": "TF_GCP_25" 
-                }
-            }
-        }
-    }
+test_not_deny_workloadidentity_nodes_exclusions if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"//": "TF_GCP_25",
+	}}}}
 
-    t.no_errors(deny_gke_workloadidentity_nodes_disabled) with input as input
+	t.no_errors(deny_gke_workloadidentity_nodes_disabled) with input as inp
 }
 
-test_deny_missing_workloadidentity_nodes_config {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test": {
-                    "cluster": "cluster1",
-                    "name": "test",
-                    "node_config": {
-                        "workload_metadata_config": {}
-                    }
-                }           
-            }
-        }
-    }
+test_deny_missing_workloadidentity_nodes_config if {
+	inp := {"resource": {"google_container_node_pool": {"test": {
+		"cluster": "cluster1",
+		"name": "test",
+		"node_config": {"workload_metadata_config": {}},
+	}}}}
 
-    t.error_count(deny_gke_workloadidentity_nodes_disabled, 1) with input as input
+	t.error_count(deny_gke_workloadidentity_nodes_disabled, 1) with input as inp
 }
 
-test_deny_workloadidentity_nodes_unspecified {
-    input := {
-        "resource": {
-            "google_container_node_pool": {
-                "test1": {
-                    "cluster": "cluster1",
-                    "name": "test1",
-                    "node_config": {
-                        "workload_metadata_config": {
-                          "node_metadata": "UNSPECIFIED"
-                        }
-                    }
-                },
-                "test2": {
-                    "cluster": "cluster2",
-                    "name": "test2",
-                    "node_config": {
-                        "workload_metadata_config": {
-                          "mode": "UNSPECIFIED"
-                        }
-                    }
-                }
-            }
-        }
-    }
+test_deny_workloadidentity_nodes_unspecified if {
+	inp := {"resource": {"google_container_node_pool": {
+		"test1": {
+			"cluster": "cluster1",
+			"name": "test1",
+			"node_config": {"workload_metadata_config": {"node_metadata": "UNSPECIFIED"}},
+		},
+		"test2": {
+			"cluster": "cluster2",
+			"name": "test2",
+			"node_config": {"workload_metadata_config": {"mode": "UNSPECIFIED"}},
+		},
+	}}}
 
-    t.error_count(deny_gke_workloadidentity_nodes_disabled, 2) with input as input
+	t.error_count(deny_gke_workloadidentity_nodes_disabled, 2) with input as inp
 }
-

--- a/policy/terraform/gcp/iam/deny_google_iam_policy.rego
+++ b/policy/terraform/gcp/iam/deny_google_iam_policy.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check04 := "TF_GCP_04"
 
 # DENY(TF_GCP_04)
-deny_iam_policy[msg] {
+deny_iam_policy contains msg if {
 	input.data.google_iam_policy
 	binding := input.data.google_iam_policy[i].binding[j]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/iam/deny_google_iam_policy_test.rego
+++ b/policy/terraform/gcp/iam/deny_google_iam_policy_test.rego
@@ -1,122 +1,81 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_iam_policy_with_exclusions {
-    input := {
-        "data": {
-            "google_iam_policy": {
-                "p": {
-                    "binding": [
-                        {
-                            "role": "roles/storage.admin",
-                            "members": [
-                                "group:test@domain.com",
-                            ],
-                        },
-                        {
-                            "//": "TF_GCP_04",
-                            "role": "roles/storage.admin",
-                            "members": [
-                                "allAuthenticatedUsers",
-                            ],
-                        },
-                    ],
-                },
-            },
-        },
-        "resource": {
-            "google_storage_bucket": {
-                "b": {
-                    "name": "b",
-                    "location": "EUROPE-WEST4",
-                    "storage_class": "STANDARD",
-                    "uniform_bucket_level_access": "true",
-                },
-            },
-            "google_storage_bucket_iam_policy": {
-                "b": {
-                    "bucket": "${google_storage_bucket.b.name}",
-                    "policy_data": "${data.google_iam_policy.p.policy_data}",
-                },
-            },
-        },
-    }
+test_not_deny_iam_policy_with_exclusions if {
+	inp := {
+		"data": {"google_iam_policy": {"p": {"binding": [
+			{
+				"role": "roles/storage.admin",
+				"members": ["group:test@domain.com"],
+			},
+			{
+				"//": "TF_GCP_04",
+				"role": "roles/storage.admin",
+				"members": ["allAuthenticatedUsers"],
+			},
+		]}}},
+		"resource": {
+			"google_storage_bucket": {"b": {
+				"name": "b",
+				"location": "EUROPE-WEST4",
+				"storage_class": "STANDARD",
+				"uniform_bucket_level_access": "true",
+			}},
+			"google_storage_bucket_iam_policy": {"b": {
+				"bucket": "${google_storage_bucket.b.name}",
+				"policy_data": "${data.google_iam_policy.p.policy_data}",
+			}},
+		},
+	}
 
-   t.no_errors(deny_iam_policy) with input as input
+	t.no_errors(deny_iam_policy) with input as inp
 }
 
-test_deny_iam_policy {
-    input := {
-        "data": {
-            "google_iam_policy": {
-                "p": {
-                    "binding": [
-                        {
-                            "role": "roles/storage.admin",
-                            "members": [
-                                "allUsers",
-                            ],
-                        },
-                    ],
-                },
-            },
-        },
-        "resource": {
-            "google_storage_bucket": {
-                "b": {
-                    "name": "b",
-                    "location": "EUROPE-WEST4",
-                    "storage_class": "STANDARD",
-                    "uniform_bucket_level_access": "true",
-                },
-            },
-            "google_storage_bucket_iam_policy": {
-                "b": {
-                    "bucket": "${google_storage_bucket.b.name}",
-                    "policy_data": "${data.google_iam_policy.p.policy_data}",
-                },
-            },
-        },
-    }
+test_deny_iam_policy if {
+	inp := {
+		"data": {"google_iam_policy": {"p": {"binding": [{
+			"role": "roles/storage.admin",
+			"members": ["allUsers"],
+		}]}}},
+		"resource": {
+			"google_storage_bucket": {"b": {
+				"name": "b",
+				"location": "EUROPE-WEST4",
+				"storage_class": "STANDARD",
+				"uniform_bucket_level_access": "true",
+			}},
+			"google_storage_bucket_iam_policy": {"b": {
+				"bucket": "${google_storage_bucket.b.name}",
+				"policy_data": "${data.google_iam_policy.p.policy_data}",
+			}},
+		},
+	}
 
-    t.error_count(deny_iam_policy, 1) with input as input
+	t.error_count(deny_iam_policy, 1) with input as inp
 }
 
+test_not_deny_iam_policy if {
+	inp := {
+		"data": {"google_iam_policy": {"p": {"binding": [{
+			"role": "roles/storage.admin",
+			"members": ["group:test@domain.com"],
+		}]}}},
+		"resource": {
+			"google_storage_bucket": {"b": {
+				"name": "b",
+				"location": "EUROPE-WEST4",
+				"storage_class": "STANDARD",
+				"uniform_bucket_level_access": "true",
+			}},
+			"google_storage_bucket_iam_policy": {"b": {
+				"bucket": "${google_storage_bucket.b.name}",
+				"policy_data": "${data.google_iam_policy.p.policy_data}",
+			}},
+		},
+	}
 
-test_not_deny_iam_policy {
-    input := {
-        "data": {
-            "google_iam_policy": {
-                "p": {
-                    "binding": [
-                        {
-                            "role": "roles/storage.admin",
-                            "members": [
-                                "group:test@domain.com",
-                            ],
-                        },
-                    ],
-                },
-            },
-        },
-        "resource": {
-            "google_storage_bucket": {
-                "b": {
-                    "name": "b",
-                    "location": "EUROPE-WEST4",
-                    "storage_class": "STANDARD",
-                    "uniform_bucket_level_access": "true",
-                },
-            },
-            "google_storage_bucket_iam_policy": {
-                "b": {
-                    "bucket": "${google_storage_bucket.b.name}",
-                    "policy_data": "${data.google_iam_policy.p.policy_data}",
-                },
-            },
-        },
-    }
-
-   t.no_errors(deny_iam_policy) with input as input
+	t.no_errors(deny_iam_policy) with input as inp
 }

--- a/policy/terraform/gcp/iam/deny_google_iam_user.rego
+++ b/policy/terraform/gcp/iam/deny_google_iam_user.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check44 := "TF_GCP_44"
 
 # DENY(TF_GCP_44)
-deny_user_org_member[msg] {
+deny_user_org_member contains msg if {
 	input.resource.google_organization_iam_member
 	member := input.resource.google_organization_iam_member[i]
 	not make_exception(check44, member)
@@ -15,7 +17,7 @@ deny_user_org_member[msg] {
 	msg = sprintf("%s: prefer group/service_account over user, [%s] not allowed on org level. More info: %s", [check44, member.member, l.get_url(check44)])
 }
 
-deny_user_folder_member[msg] {
+deny_user_folder_member contains msg if {
 	input.resource.google_folder_iam_member
 	member := input.resource.google_folder_iam_member[i]
 	not make_exception(check44, member)
@@ -24,7 +26,7 @@ deny_user_folder_member[msg] {
 	msg = sprintf("%s: prefer group/service_account over user, [%s] not allowed on folder level. More info: %s", [check44, member.member, l.get_url(check44)])
 }
 
-deny_user_proj_member[msg] {
+deny_user_proj_member contains msg if {
 	input.resource.google_project_iam_member
 	member := input.resource.google_project_iam_member[i]
 	not make_exception(check44, member)

--- a/policy/terraform/gcp/iam/deny_google_iam_user_test.rego
+++ b/policy/terraform/gcp/iam/deny_google_iam_user_test.rego
@@ -1,69 +1,49 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_user_org_member {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "role": "roles/container.developer",
-                    "member": "user:test@domain.com"
-                }
-            }
-        }
-    }
+test_deny_user_org_member if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"role": "roles/container.developer",
+		"member": "user:test@domain.com",
+	}}}}
 
-    t.error_count(deny_user_org_member, 1) with input as input
+	t.error_count(deny_user_org_member, 1) with input as inp
 }
 
-test_not_deny_deny_user_org_member_when_exception {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_44",
-                    "role": "roles/container.developer",
-                    "member": "user:test@domain.com"
-                }
-            }
-        }
-    }
+test_not_deny_deny_user_org_member_when_exception if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"//": "TF_GCP_44",
+		"role": "roles/container.developer",
+		"member": "user:test@domain.com",
+	}}}}
 
-    t.no_errors(deny_user_org_member) with input as input
+	t.no_errors(deny_user_org_member) with input as inp
 }
 
-test_not_deny_deny_user_org_member_when_group {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "role": "roles/container.developer",
-                    "member": "group:test@domain.com"
-                }
-            }
-        }
-    }
+test_not_deny_deny_user_org_member_when_group if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"role": "roles/container.developer",
+		"member": "group:test@domain.com",
+	}}}}
 
-    t.no_errors(deny_user_org_member) with input as input
+	t.no_errors(deny_user_org_member) with input as inp
 }
 
-test_deny_user_org_more_members {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_44",
-                    "role": "roles/container.developer",
-                    "member": "user:test@domain.com"
-                },
-                "should be blocked": {
-                    "role": "roles/container.developer",
-                    "member": "user:test2@domain.com"
-                }
-            }
-        }
-    }
+test_deny_user_org_more_members if {
+	inp := {"resource": {"google_organization_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_44",
+			"role": "roles/container.developer",
+			"member": "user:test@domain.com",
+		},
+		"should be blocked": {
+			"role": "roles/container.developer",
+			"member": "user:test2@domain.com",
+		},
+	}}}
 
-    t.error_count(deny_user_org_member, 1) with input as input
+	t.error_count(deny_user_org_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/iam/deny_google_impersonation_roles_binding.rego
+++ b/policy/terraform/gcp/iam/deny_google_impersonation_roles_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check18 := "TF_GCP_18"
 
 # DENY(TF_GCP_18)
-deny_impersonation_roles_org_binding[msg] {
+deny_impersonation_roles_org_binding contains msg if {
 	input.resource.google_organization_iam_binding
 	binding := input.resource.google_organization_iam_binding[i]
 	binding.role == impersonation_roles[role]
@@ -15,7 +17,7 @@ deny_impersonation_roles_org_binding[msg] {
 	msg = sprintf("%s: impersonation role [%s] not allowed on org level. More info: %s", [check18, binding.role, l.get_url(check18)])
 }
 
-deny_impersonation_roles_folder_binding[msg] {
+deny_impersonation_roles_folder_binding contains msg if {
 	input.resource.google_folder_iam_binding
 	binding := input.resource.google_folder_iam_binding[i]
 	binding.role == impersonation_roles[role]
@@ -24,7 +26,7 @@ deny_impersonation_roles_folder_binding[msg] {
 	msg = sprintf("%s: impersonation role [%s] not allowed on folder level. More info: %s", [check18, binding.role, l.get_url(check18)])
 }
 
-deny_impersonation_roles_proj_binding[msg] {
+deny_impersonation_roles_proj_binding contains msg if {
 	input.resource.google_project_iam_binding
 	binding := input.resource.google_project_iam_binding[i]
 	binding.role == impersonation_roles[role]

--- a/policy/terraform/gcp/iam/deny_google_impersonation_roles_binding_test.rego
+++ b/policy/terraform/gcp/iam/deny_google_impersonation_roles_binding_test.rego
@@ -1,62 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_impersonation_roles_org_member {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "members": [
-                        "group:test@domain.com",
-                    ]
-                }
-            }
-        }
-    }
+test_deny_impersonation_roles_org_member if {
+	inp := {"resource": {"google_organization_iam_binding": {"public-member": {
+		"role": "roles/iam.serviceAccountTokenCreator",
+		"members": ["group:test@domain.com"],
+	}}}}
 
-    t.error_count(deny_impersonation_roles_org_binding, 1) with input as input
+	t.error_count(deny_impersonation_roles_org_binding, 1) with input as inp
 }
 
-test_not_deny_impersonation_roles_org_member_when_exception {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_18",
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "members": [
-                        "group:test@domain.com",
-                    ]
-                }
-            }
-        }
-    }
+test_not_deny_impersonation_roles_org_member_when_exception if {
+	inp := {"resource": {"google_organization_iam_binding": {"public-member": {
+		"//": "TF_GCP_18",
+		"role": "roles/iam.serviceAccountTokenCreator",
+		"members": ["group:test@domain.com"],
+	}}}}
 
-    t.no_errors(deny_impersonation_roles_org_binding) with input as input
+	t.no_errors(deny_impersonation_roles_org_binding) with input as inp
 }
 
-test_deny_default_sa_org_member_more_members {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_18",
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "members": [
-                        "group:test@domain.com",
-                    ]
-                },
-                "should be blocked": {
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "members": [
-                        "group:test@domain.com",
-                    ]
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_member_more_members if {
+	inp := {"resource": {"google_organization_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_18",
+			"role": "roles/iam.serviceAccountTokenCreator",
+			"members": ["group:test@domain.com"],
+		},
+		"should be blocked": {
+			"role": "roles/iam.serviceAccountTokenCreator",
+			"members": ["group:test@domain.com"],
+		},
+	}}}
 
-    t.error_count(deny_impersonation_roles_org_binding, 1) with input as input
+	t.error_count(deny_impersonation_roles_org_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/iam/deny_google_impersonation_roles_member.rego
+++ b/policy/terraform/gcp/iam/deny_google_impersonation_roles_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check17 := "TF_GCP_17"
 
 # DENY(TF_GCP_17)
-deny_impersonation_roles_org_member[msg] {
+deny_impersonation_roles_org_member contains msg if {
 	input.resource.google_organization_iam_member
 	member := input.resource.google_organization_iam_member[i]
 	member.role == impersonation_roles[role]
@@ -15,7 +17,7 @@ deny_impersonation_roles_org_member[msg] {
 	msg = sprintf("%s: impersonation role [%s] on member [%s] not allowed on org level. More info: %s", [check17, member.role, member.member, l.get_url(check17)])
 }
 
-deny_impersonation_roles_folder_member[msg] {
+deny_impersonation_roles_folder_member contains msg if {
 	input.resource.google_folder_iam_member
 	member := input.resource.google_folder_iam_member[i]
 	member.role == impersonation_roles[role]
@@ -24,7 +26,7 @@ deny_impersonation_roles_folder_member[msg] {
 	msg = sprintf("%s: impersonation role [%s] on member [%s] not allowed on folder level. More info: %s", [check17, member.role, member.member, l.get_url(check17)])
 }
 
-deny_impersonation_roles_proj_member[msg] {
+deny_impersonation_roles_proj_member contains msg if {
 	input.resource.google_project_iam_member
 	member := input.resource.google_project_iam_member[i]
 	member.role == impersonation_roles[role]

--- a/policy/terraform/gcp/iam/deny_google_impersonation_roles_member_test.rego
+++ b/policy/terraform/gcp/iam/deny_google_impersonation_roles_member_test.rego
@@ -1,54 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_impersonation_roles_org_member {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "member": "test@domain.com"
-                }
-            }
-        }
-    }
+test_deny_impersonation_roles_org_member if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"role": "roles/iam.serviceAccountTokenCreator",
+		"member": "test@domain.com",
+	}}}}
 
-    t.error_count(deny_impersonation_roles_org_member, 1) with input as input
+	t.error_count(deny_impersonation_roles_org_member, 1) with input as inp
 }
 
-test_not_deny_impersonation_roles_org_member_when_exception {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_17",
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "member": "test@domain.com"
-                }
-            }
-        }
-    }
+test_not_deny_impersonation_roles_org_member_when_exception if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"//": "TF_GCP_17",
+		"role": "roles/iam.serviceAccountTokenCreator",
+		"member": "test@domain.com",
+	}}}}
 
-    t.no_errors(deny_impersonation_roles_org_member) with input as input
+	t.no_errors(deny_impersonation_roles_org_member) with input as inp
 }
 
-test_deny_default_sa_org_member_more_members {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_17",
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "member": "test@domain.com"
-                },
-                "should be blocked": {
-                    "role": "roles/iam.serviceAccountTokenCreator",
-                    "member": "test2@domain.com"
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_member_more_members if {
+	inp := {"resource": {"google_organization_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_17",
+			"role": "roles/iam.serviceAccountTokenCreator",
+			"member": "test@domain.com",
+		},
+		"should be blocked": {
+			"role": "roles/iam.serviceAccountTokenCreator",
+			"member": "test2@domain.com",
+		},
+	}}}
 
-    t.error_count(deny_impersonation_roles_org_member, 1) with input as input
+	t.error_count(deny_impersonation_roles_org_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/iap/deny_iap_no_host_condition.rego
+++ b/policy/terraform/gcp/iap/deny_iap_no_host_condition.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check43 := "TF_GCP_43"
 
-doesnt_have_host_condition(member) {
+doesnt_have_host_condition(member) if {
 	not member.condition.expression
-} else {
+} else if {
 	not contains(member.condition.expression, "request.host")
 }
 
 # DENY(TF_GCP_43)
-deny_iap_no_host_condition[msg] {
+deny_iap_no_host_condition contains msg if {
 	input.resource.google_iap_web_iam_member
 	member := input.resource.google_iap_web_iam_member[k]
 	not make_exception(check43, member)

--- a/policy/terraform/gcp/iap/deny_iap_no_host_condition_test.rego
+++ b/policy/terraform/gcp/iap/deny_iap_no_host_condition_test.rego
@@ -1,81 +1,53 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_iap_no_host_condition {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "group:test@test.com"
-                }
-            }
-        }
-    }
+test_deny_iap_no_host_condition if {
+	inp := {"resource": {"google_iap_web_iam_member": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "group:test@test.com",
+	}}}}
 
-    t.error_count(deny_iap_no_host_condition, 1) with input as input
+	t.error_count(deny_iap_no_host_condition, 1) with input as inp
 }
 
-test_not_iap_no_host_condition_when_exception {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_43",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "group:test@test.com",
-                    "condition": {
-                        "expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"
-                    },
-                }
-            }
-        }
-    }
+test_not_iap_no_host_condition_when_exception if {
+	inp := {"resource": {"google_iap_web_iam_member": {"public-member": {
+		"//": "TF_GCP_43",
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "group:test@test.com",
+		"condition": {"expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"},
+	}}}}
 
-    t.no_errors(deny_iap_no_host_condition) with input as input
+	t.no_errors(deny_iap_no_host_condition) with input as inp
 }
 
-test_deny_iap_no_host_multiple {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_43",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "test@test.com",
-                    "condition": {
-                        "expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"
-                    }
-                },
-                "should be blocked": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "test@test.com",
-                    "condition": {
-                        "expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"
-                    }
-                }
-            }
-        }
-    }
+test_deny_iap_no_host_multiple if {
+	inp := {"resource": {"google_iap_web_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_43",
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "test@test.com",
+			"condition": {"expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"},
+		},
+		"should be blocked": {
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "test@test.com",
+			"condition": {"expression": "request.time < timestamp(\"2020-01-01T00:00:00Z\")"},
+		},
+	}}}
 
-    t.error_count(deny_iap_no_host_condition, 1) with input as input
+	t.error_count(deny_iap_no_host_condition, 1) with input as inp
 }
 
-test_not_deny_iap_with_condition {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "test@test.com",
-                    "condition": {
-                        "expression": "request.host == \"google.com\""
-                    },
-                },
-            }
-        }
-    }
+test_not_deny_iap_with_condition if {
+	inp := {"resource": {"google_iap_web_iam_member": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "test@test.com",
+		"condition": {"expression": "request.host == \"google.com\""},
+	}}}}
 
-    t.no_errors(deny_iap_no_host_condition) with input as input
+	t.no_errors(deny_iap_no_host_condition) with input as inp
 }

--- a/policy/terraform/gcp/iap/deny_iap_public_binding.rego
+++ b/policy/terraform/gcp/iap/deny_iap_public_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check13 := "TF_GCP_13"
 
 # DENY(TF_GCP_13)
-deny_iap_public_binding[msg] {
+deny_iap_public_binding contains msg if {
 	input.resource.google_iap_web_iam_binding
 	binding := input.resource.google_iap_web_iam_binding[k]
 	binding.members[member] == blacklisted_users[user]

--- a/policy/terraform/gcp/iap/deny_iap_public_binding_test.rego
+++ b/policy/terraform/gcp/iap/deny_iap_public_binding_test.rego
@@ -1,54 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_iap_public_binding {
-    input := {
-        "resource": {
-            "google_iap_web_iam_binding": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_iap_public_binding if {
+	inp := {"resource": {"google_iap_web_iam_binding": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"members": ["allUsers", "group:test@embark.dev"],
+	}}}}
 
-    t.error_count(deny_iap_public_binding, 1) with input as input
+	t.error_count(deny_iap_public_binding, 1) with input as inp
 }
 
-test_not_deny_iap_public_binding_when_exception {
-    input := {
-        "resource": {
-            "google_iap_web_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_13",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_not_deny_iap_public_binding_when_exception if {
+	inp := {"resource": {"google_iap_web_iam_binding": {"public-member": {
+		"//": "TF_GCP_13",
+		"role": "roles/iap.httpsResourceAccessor",
+		"members": ["group:test@embark.dev"],
+	}}}}
 
-    t.no_errors(deny_iap_public_binding) with input as input
+	t.no_errors(deny_iap_public_binding) with input as inp
 }
 
-test_deny_iap_public_binding_more_members {
-    input := {
-        "resource": {
-            "google_iap_web_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_13",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                },
-                "should be blocked": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["allUsers", "group:test@embark.dev"]
-                }
-            }
-        }
-    }
+test_deny_iap_public_binding_more_members if {
+	inp := {"resource": {"google_iap_web_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_13",
+			"role": "roles/iap.httpsResourceAccessor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+		"should be blocked": {
+			"role": "roles/iap.httpsResourceAccessor",
+			"members": ["allUsers", "group:test@embark.dev"],
+		},
+	}}}
 
-    t.error_count(deny_iap_public_binding, 1) with input as input
+	t.error_count(deny_iap_public_binding, 1) with input as inp
 }

--- a/policy/terraform/gcp/iap/deny_iap_public_member.rego
+++ b/policy/terraform/gcp/iap/deny_iap_public_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check12 := "TF_GCP_12"
 
 # DENY(TF_GCP_12)
-deny_iap_public_member[msg] {
+deny_iap_public_member contains msg if {
 	input.resource.google_iap_web_iam_member
 	member := input.resource.google_iap_web_iam_member[k]
 	l.contains_element(blacklisted_users, member.member)

--- a/policy/terraform/gcp/iap/deny_iap_public_member_test.rego
+++ b/policy/terraform/gcp/iap/deny_iap_public_member_test.rego
@@ -1,54 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_iap_public_member {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_iap_public_member if {
+	inp := {"resource": {"google_iap_web_iam_member": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "allUsers",
+	}}}}
 
-    t.error_count(deny_iap_public_member, 1) with input as input
+	t.error_count(deny_iap_public_member, 1) with input as inp
 }
 
-test_not_deny_iap_public_member_when_exception {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_12",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_not_deny_iap_public_member_when_exception if {
+	inp := {"resource": {"google_iap_web_iam_member": {"public-member": {
+		"//": "TF_GCP_12",
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "allUsers",
+	}}}}
 
-    t.no_errors(deny_iap_public_member) with input as input
+	t.no_errors(deny_iap_public_member) with input as inp
 }
 
-test_deny_iap_public_member_more_members {
-    input := {
-        "resource": {
-            "google_iap_web_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_12",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "allUsers"
-                },
-                "should be blocked": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "allUsers"
-                }
-            }
-        }
-    }
+test_deny_iap_public_member_more_members if {
+	inp := {"resource": {"google_iap_web_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_12",
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "allUsers",
+		},
+		"should be blocked": {
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "allUsers",
+		},
+	}}}
 
-    t.error_count(deny_iap_public_member, 1) with input as input
+	t.error_count(deny_iap_public_member, 1) with input as inp
 }

--- a/policy/terraform/gcp/kms/deny_kms_crypto_key_public.rego
+++ b/policy/terraform/gcp/kms/deny_kms_crypto_key_public.rego
@@ -1,11 +1,13 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
-check30 = "TF_GCP_30"
+check30 := "TF_GCP_30"
 
-deny_kms_crypto_key_iam_member_public[msg] {
+deny_kms_crypto_key_iam_member_public contains msg if {
 	input.resource.google_kms_crypto_key_iam_member
 	iam := input.resource.google_kms_crypto_key_iam_member[key]
 
@@ -16,9 +18,9 @@ deny_kms_crypto_key_iam_member_public[msg] {
 	msg = sprintf("%s: KMS Crypto Key %s is accessible to public. More info: %s", [check30, key, l.get_url(check30)])
 }
 
-check31 = "TF_GCP_31"
+check31 := "TF_GCP_31"
 
-deny_kms_crypto_key_iam_binding_public[msg] {
+deny_kms_crypto_key_iam_binding_public contains msg if {
 	input.resource.google_kms_crypto_key_iam_binding
 	iam := input.resource.google_kms_crypto_key_iam_binding[key]
 

--- a/policy/terraform/gcp/kms/deny_kms_crypto_key_public_test.rego
+++ b/policy/terraform/gcp/kms/deny_kms_crypto_key_public_test.rego
@@ -1,89 +1,75 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_public_kms_crypto_key_iam_member {
-   input := {
-       "resource": {
-           "google_kms_crypto_key_iam_member": {
-               "allUsers": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "member": "allUsers",
-               },
-               "allAuthenticated": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "member": "allAuthenticatedUsers",
-               },
-           }
-       }
-   }
+test_deny_public_kms_crypto_key_iam_member if {
+	inp := {"resource": {"google_kms_crypto_key_iam_member": {
+		"allUsers": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"member": "allUsers",
+		},
+		"allAuthenticated": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"member": "allAuthenticatedUsers",
+		},
+	}}}
 
-   t.error_count(deny_kms_crypto_key_iam_member_public, 2) with input as input
+	t.error_count(deny_kms_crypto_key_iam_member_public, 2) with input as inp
 }
 
-test_allow_valid_kms_crypto_key_iam_member {
-   input := {
-       "resource": {
-           "google_kms_crypto_key_iam_member": {
-               "allUsers": {
-                   "//": "TF_GCP_30",
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "member": "allUsers",
-               },
-               "validUser": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "member": "user:jane@example.com",
-               },
-           }
-       }
-   }
+test_allow_valid_kms_crypto_key_iam_member if {
+	inp := {"resource": {"google_kms_crypto_key_iam_member": {
+		"allUsers": {
+			"//": "TF_GCP_30",
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"member": "allUsers",
+		},
+		"validUser": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"member": "user:jane@example.com",
+		},
+	}}}
 
-   t.no_errors(deny_kms_crypto_key_iam_member_public) with input as input
+	t.no_errors(deny_kms_crypto_key_iam_member_public) with input as inp
 }
 
-test_deny_public_kms_crypto_key_iam_binding {
-   input := {
-       "resource": {
-           "google_kms_crypto_key_iam_binding": {
-               "allUsers": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "members": ["allUsers"],
-               },
-               "allAuthenticated": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "members": ["allAuthenticatedUsers"],
-               },
-           }
-       }
-   }
+test_deny_public_kms_crypto_key_iam_binding if {
+	inp := {"resource": {"google_kms_crypto_key_iam_binding": {
+		"allUsers": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"members": ["allUsers"],
+		},
+		"allAuthenticated": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"members": ["allAuthenticatedUsers"],
+		},
+	}}}
 
-   t.error_count(deny_kms_crypto_key_iam_binding_public, 2) with input as input
+	t.error_count(deny_kms_crypto_key_iam_binding_public, 2) with input as inp
 }
 
-test_allow_valid_kms_crypto_key_iam_binding {
-   input := {
-       "resource": {
-           "google_kms_crypto_key_iam_binding": {
-               "allUsers": {
-                   "//": "TF_GCP_31",
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "members": ["allUsers"],
-               },
-               "validUsers": {
-                   "crypto_key_id": "some-id",
-                   "role": "roles/cloudkms.cryptoKeyEncrypter",
-                   "members": ["user:jane@example.com"],
-               },
-           }
-       }
-   }
+test_allow_valid_kms_crypto_key_iam_binding if {
+	inp := {"resource": {"google_kms_crypto_key_iam_binding": {
+		"allUsers": {
+			"//": "TF_GCP_31",
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"members": ["allUsers"],
+		},
+		"validUsers": {
+			"crypto_key_id": "some-id",
+			"role": "roles/cloudkms.cryptoKeyEncrypter",
+			"members": ["user:jane@example.com"],
+		},
+	}}}
 
-   t.no_errors(deny_kms_crypto_key_iam_binding_public) with input as input
+	t.no_errors(deny_kms_crypto_key_iam_binding_public) with input as inp
 }

--- a/policy/terraform/gcp/kms/deny_kms_crypto_key_rotation_too_long.rego
+++ b/policy/terraform/gcp/kms/deny_kms_crypto_key_rotation_too_long.rego
@@ -1,20 +1,22 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
-check35 = "TF_GCP_35"
+check35 := "TF_GCP_35"
 
-invalid_rotation_period(key) {
+invalid_rotation_period(key) if {
 	not key.rotation_period
-} else {
+} else if {
 	seconds := trim_right(key.rotation_period, "s")
 
 	# 90 days = 7776000 seconds
 	to_number(seconds) > 7776000
 }
 
-deny_kms_crypto_key_rotation_too_long[msg] {
+deny_kms_crypto_key_rotation_too_long contains msg if {
 	input.resource.google_kms_crypto_key
 
 	key := input.resource.google_kms_crypto_key[_]

--- a/policy/terraform/gcp/kms/deny_kms_crypto_key_rotation_too_long_test.rego
+++ b/policy/terraform/gcp/kms/deny_kms_crypto_key_rotation_too_long_test.rego
@@ -1,66 +1,46 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_kms_crypto_key_rotation_too_long {
-   input := {
-       "resource": {
-           "google_kms_crypto_key": {
-               "key1": {
-                   "name"     : "undefined",
-                   "key_ring" : "${google_kms_key_ring.keyring.id}",
-                   "purpose"  : "ASYMMETRIC_SIGN",
+test_deny_kms_crypto_key_rotation_too_long if {
+	inp := {"resource": {"google_kms_crypto_key": {
+		"key1": {
+			"name": "undefined",
+			"key_ring": "${google_kms_key_ring.keyring.id}",
+			"purpose": "ASYMMETRIC_SIGN",
+			"version_template": {"algorithm": "EC_SIGN_P384_SHA384"},
+		},
+		"key2": {
+			"name": "too-long",
+			"key_ring": "${google_kms_key_ring.keyring.id}",
+			"purpose": "ASYMMETRIC_SIGN",
+			"rotation_period": "7776001s",
+			"version_template": {"algorithm": "EC_SIGN_P384_SHA384"},
+		},
+	}}}
 
-                   "version_template": {
-                     "algorithm" : "EC_SIGN_P384_SHA384",
-                   }
-               },
-               "key2": {
-                   "name"     : "too-long",
-                   "key_ring" : "${google_kms_key_ring.keyring.id}",
-                   "purpose"  : "ASYMMETRIC_SIGN",
-
-                   "rotation_period" : "7776001s",
-
-                   "version_template": {
-                     "algorithm" : "EC_SIGN_P384_SHA384",
-                   }
-               }
-           }
-       }
-   }
-
-   t.error_count(deny_kms_crypto_key_rotation_too_long, 2) with input as input
+	t.error_count(deny_kms_crypto_key_rotation_too_long, 2) with input as inp
 }
 
-test_allow_valid_kms_crypto_key_rotation {
-   input := {
-       "resource": {
-           "google_kms_crypto_key": {
-               "key1": {
-                   "name"     : "excepted",
-                   "key_ring" : "${google_kms_key_ring.keyring.id}",
-                   "purpose"  : "ASYMMETRIC_SIGN",
-                   "//": "TF_GCP_35",
+test_allow_valid_kms_crypto_key_rotation if {
+	inp := {"resource": {"google_kms_crypto_key": {
+		"key1": {
+			"name": "excepted",
+			"key_ring": "${google_kms_key_ring.keyring.id}",
+			"purpose": "ASYMMETRIC_SIGN",
+			"//": "TF_GCP_35",
+			"version_template": {"algorithm": "EC_SIGN_P384_SHA384"},
+		},
+		"key2": {
+			"name": "valid",
+			"key_ring": "${google_kms_key_ring.keyring.id}",
+			"purpose": "ASYMMETRIC_SIGN",
+			"rotation_period": "7776000s",
+			"version_template": {"algorithm": "EC_SIGN_P384_SHA384"},
+		},
+	}}}
 
-                   "version_template": {
-                     "algorithm" : "EC_SIGN_P384_SHA384",
-                   }
-               },
-               "key2": {
-                   "name"     : "valid",
-                   "key_ring" : "${google_kms_key_ring.keyring.id}",
-                   "purpose"  : "ASYMMETRIC_SIGN",
-
-                   "rotation_period" : "7776000s",
-
-                   "version_template": {
-                     "algorithm" : "EC_SIGN_P384_SHA384",
-                   }
-               }
-           }
-       }
-   }
-
-   t.no_errors(deny_kms_crypto_key_rotation_too_long) with input as input
+	t.no_errors(deny_kms_crypto_key_rotation_too_long) with input as inp
 }

--- a/policy/terraform/gcp/memorystore/deny_redis_auth.rego
+++ b/policy/terraform/gcp/memorystore/deny_redis_auth.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check49 := "TF_GCP_49"
 
-not_exists_or_false(redis) {
+not_exists_or_false(redis) if {
 	not redis.auth_enabled
-} else {
+} else if {
 	not l.is_true(redis.auth_enabled)
 }
 
 # DENY(TF_GCP_49)
-deny_memorystore_redis_no_auth[msg] {
+deny_memorystore_redis_no_auth contains msg if {
 	input.resource.google_redis_instance
 	redis := input.resource.google_redis_instance[i]
 	not make_exception(check49, redis)

--- a/policy/terraform/gcp/memorystore/deny_redis_auth_test.rego
+++ b/policy/terraform/gcp/memorystore/deny_redis_auth_test.rego
@@ -1,63 +1,39 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_memorystore_redis_no_auth_no_prop {
-    input := {
-        "resource": {
-            "google_redis_instance": {
-                "test": {
-                    "name": "test"
-                }
-            }
-        }
-    }
+test_deny_memorystore_redis_no_auth_no_prop if {
+	inp := {"resource": {"google_redis_instance": {"test": {"name": "test"}}}}
 
-    t.error_count(deny_memorystore_redis_no_auth, 1) with input as input
+	t.error_count(deny_memorystore_redis_no_auth, 1) with input as inp
 }
 
-test_deny_memorystore_redis_no_auth_false_string {
-    input := {
-        "resource": {
-            "google_redis_instance": {
-                "test": {
-                    "name": "test",
-                    "auth_enabled": "false"
-                }
-            }
-        }
-    }
+test_deny_memorystore_redis_no_auth_false_string if {
+	inp := {"resource": {"google_redis_instance": {"test": {
+		"name": "test",
+		"auth_enabled": "false",
+	}}}}
 
-    t.error_count(deny_memorystore_redis_no_auth, 1) with input as input
+	t.error_count(deny_memorystore_redis_no_auth, 1) with input as inp
 }
 
-test_deny_memorystore_redis_no_auth_false_native {
-    input := {
-        "resource": {
-            "google_redis_instance": {
-                "test": {
-                    "name": "test",
-                    "auth_enabled": false
-                }
-            }
-        }
-    }
+test_deny_memorystore_redis_no_auth_false_native if {
+	inp := {"resource": {"google_redis_instance": {"test": {
+		"name": "test",
+		"auth_enabled": false,
+	}}}}
 
-    t.error_count(deny_memorystore_redis_no_auth, 1) with input as input
+	t.error_count(deny_memorystore_redis_no_auth, 1) with input as inp
 }
 
-test_not_deny_memorystore_redis_no_auth_with_exception {
-    input := {
-        "resource": {
-            "google_redis_instance": {
-                "test": {
-                    "//": "TF_GCP_49",
-                    "name": "test",
-                    "auth_enabled": "false"
-                }
-            }
-        }
-    }
+test_not_deny_memorystore_redis_no_auth_with_exception if {
+	inp := {"resource": {"google_redis_instance": {"test": {
+		"//": "TF_GCP_49",
+		"name": "test",
+		"auth_enabled": "false",
+	}}}}
 
-    t.no_errors(deny_memorystore_redis_no_auth) with input as input
+	t.no_errors(deny_memorystore_redis_no_auth) with input as inp
 }

--- a/policy/terraform/gcp/org/deny_google_folder_default_sa_binding.rego
+++ b/policy/terraform/gcp/org/deny_google_folder_default_sa_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check38 := "TF_GCP_38"
 
 # DENY(TF_GCP_38)
-deny_default_sa_binding_on_folder_level[msg] {
+deny_default_sa_binding_on_folder_level contains msg if {
 	input.resource.google_folder_iam_binding
 	binding := input.resource.google_folder_iam_binding[_]
 

--- a/policy/terraform/gcp/org/deny_google_folder_default_sa_binding_test.rego
+++ b/policy/terraform/gcp/org/deny_google_folder_default_sa_binding_test.rego
@@ -1,47 +1,33 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_default_sa_folder_binding {
-    input := {
-        "resource": {
-            "google_folder_iam_binding": {
-                "public": {
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-                    "members": [
-                        "88888888-compute@developer.gserviceaccount.com",
-                    ],
-                }
-            }
-        }
-    }
+test_deny_default_sa_folder_binding if {
+	inp := {"resource": {"google_folder_iam_binding": {"public": {
+		"folder": "folder/1234",
+		"role": "roles/viewer",
+		"members": ["88888888-compute@developer.gserviceaccount.com"],
+	}}}}
 
-    t.error_count(deny_default_sa_binding_on_folder_level, 1) with input as input
+	t.error_count(deny_default_sa_binding_on_folder_level, 1) with input as inp
 }
 
-test_allow_valid_sa_folder_binding {
-    input := {
-        "resource": {
-            "google_folder_iam_binding": {
-                "valid": {
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-					"members": [
-                        "my-service@my-project.iam.gserviceaccount.com",
-                    ],
-                },
-                "excepted": {
-                    "//": "TF_GCP_38",
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-                    "members": [
-                        "88888888-compute@developer.gserviceaccount.com",
-                    ],
-                },
-            }
-        }
-    }
+test_allow_valid_sa_folder_binding if {
+	inp := {"resource": {"google_folder_iam_binding": {
+		"valid": {
+			"folder": "folder/1234",
+			"role": "roles/viewer",
+			"members": ["my-service@my-project.iam.gserviceaccount.com"],
+		},
+		"excepted": {
+			"//": "TF_GCP_38",
+			"folder": "folder/1234",
+			"role": "roles/viewer",
+			"members": ["88888888-compute@developer.gserviceaccount.com"],
+		},
+	}}}
 
-    t.no_errors(deny_default_sa_binding_on_folder_level) with input as input
+	t.no_errors(deny_default_sa_binding_on_folder_level) with input as inp
 }

--- a/policy/terraform/gcp/org/deny_google_folder_default_sa_member.rego
+++ b/policy/terraform/gcp/org/deny_google_folder_default_sa_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check37 := "TF_GCP_37"
 
 # DENY(TF_GCP_37)
-deny_default_sa_member_on_folder_level[msg] {
+deny_default_sa_member_on_folder_level contains msg if {
 	input.resource.google_folder_iam_member
 	member := input.resource.google_folder_iam_member[i]
 

--- a/policy/terraform/gcp/org/deny_google_folder_default_sa_member_test.rego
+++ b/policy/terraform/gcp/org/deny_google_folder_default_sa_member_test.rego
@@ -1,41 +1,33 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_default_sa_folder_member {
-    input := {
-        "resource": {
-            "google_folder_iam_member": {
-                "public": {
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-                    "member": "88888888-compute@developer.gserviceaccount.com",
-                }
-            }
-        }
-    }
+test_deny_default_sa_folder_member if {
+	inp := {"resource": {"google_folder_iam_member": {"public": {
+		"folder": "folder/1234",
+		"role": "roles/viewer",
+		"member": "88888888-compute@developer.gserviceaccount.com",
+	}}}}
 
-    t.error_count(deny_default_sa_member_on_folder_level, 1) with input as input
+	t.error_count(deny_default_sa_member_on_folder_level, 1) with input as inp
 }
 
-test_allow_valid_sa_folder_member {
-    input := {
-        "resource": {
-            "google_folder_iam_member": {
-                "valid": {
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-					"member": "my-service@my-project.iam.gserviceaccount.com",
-                },
-                "excepted": {
-                    "//": "TF_GCP_37",
-                    "folder": "folder/1234",
-                    "role": "roles/viewer",
-                    "member": "88888888-compute@developer.gserviceaccount.com",
-                },
-            }
-        }
-    }
+test_allow_valid_sa_folder_member if {
+	inp := {"resource": {"google_folder_iam_member": {
+		"valid": {
+			"folder": "folder/1234",
+			"role": "roles/viewer",
+			"member": "my-service@my-project.iam.gserviceaccount.com",
+		},
+		"excepted": {
+			"//": "TF_GCP_37",
+			"folder": "folder/1234",
+			"role": "roles/viewer",
+			"member": "88888888-compute@developer.gserviceaccount.com",
+		},
+	}}}
 
-    t.no_errors(deny_default_sa_member_on_folder_level) with input as input
+	t.no_errors(deny_default_sa_member_on_folder_level) with input as inp
 }

--- a/policy/terraform/gcp/org/deny_google_org_default_sa_binding.rego
+++ b/policy/terraform/gcp/org/deny_google_org_default_sa_binding.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check16 := "TF_GCP_16"
 
 # DENY(TF_GCP_16)
-deny_default_sa_binding_on_org_level[msg] {
+deny_default_sa_binding_on_org_level contains msg if {
 	input.resource.google_organization_iam_binding
 	binding := input.resource.google_organization_iam_binding[i]
 	member := binding.members[m]

--- a/policy/terraform/gcp/org/deny_google_org_default_sa_binding_test.rego
+++ b/policy/terraform/gcp/org/deny_google_org_default_sa_binding_test.rego
@@ -1,54 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_default_sa_org_binding {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["test@test.com","88888888-compute@developer.gserviceaccount.com"]
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_binding if {
+	inp := {"resource": {"google_organization_iam_binding": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"members": ["test@test.com", "88888888-compute@developer.gserviceaccount.com"],
+	}}}}
 
-    t.error_count(deny_default_sa_binding_on_org_level, 1) with input as input
+	t.error_count(deny_default_sa_binding_on_org_level, 1) with input as inp
 }
 
-test_not_deny_default_sa_org_binding_when_exception {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_16",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["88888888-compute@developer.gserviceaccount.com"]
-                }
-            }
-        }
-    }
+test_not_deny_default_sa_org_binding_when_exception if {
+	inp := {"resource": {"google_organization_iam_binding": {"public-member": {
+		"//": "TF_GCP_16",
+		"role": "roles/iap.httpsResourceAccessor",
+		"members": ["88888888-compute@developer.gserviceaccount.com"],
+	}}}}
 
-    t.no_errors(deny_default_sa_binding_on_org_level) with input as input
+	t.no_errors(deny_default_sa_binding_on_org_level) with input as inp
 }
 
-test_deny_default_sa_org_binding_more_members {
-    input := {
-        "resource": {
-            "google_organization_iam_binding": {
-                "public-member": {
-                    "//": "TF_GCP_16",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["88888888-compute@developer.gserviceaccount.com"]
-                },
-                "should be blocked": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "members": ["7777777-compute@developer.gserviceaccount.com"]
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_binding_more_members if {
+	inp := {"resource": {"google_organization_iam_binding": {
+		"public-member": {
+			"//": "TF_GCP_16",
+			"role": "roles/iap.httpsResourceAccessor",
+			"members": ["88888888-compute@developer.gserviceaccount.com"],
+		},
+		"should be blocked": {
+			"role": "roles/iap.httpsResourceAccessor",
+			"members": ["7777777-compute@developer.gserviceaccount.com"],
+		},
+	}}}
 
-    t.error_count(deny_default_sa_binding_on_org_level, 1) with input as input
+	t.error_count(deny_default_sa_binding_on_org_level, 1) with input as inp
 }

--- a/policy/terraform/gcp/org/deny_google_org_default_sa_member.rego
+++ b/policy/terraform/gcp/org/deny_google_org_default_sa_member.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check15 := "TF_GCP_15"
 
 # DENY(TF_GCP_15)
-deny_default_sa_member_on_org_level[msg] {
+deny_default_sa_member_on_org_level contains msg if {
 	input.resource.google_organization_iam_member
 	member := input.resource.google_organization_iam_member[i]
 	regex.match(default_service_account_regexp, member.member)

--- a/policy/terraform/gcp/org/deny_google_org_default_sa_member_test.rego
+++ b/policy/terraform/gcp/org/deny_google_org_default_sa_member_test.rego
@@ -1,54 +1,40 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_deny_default_sa_org_member {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "88888888-compute@developer.gserviceaccount.com"
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_member if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "88888888-compute@developer.gserviceaccount.com",
+	}}}}
 
-    t.error_count(deny_default_sa_member_on_org_level, 1) with input as input
+	t.error_count(deny_default_sa_member_on_org_level, 1) with input as inp
 }
 
-test_not_deny_default_sa_org_member_when_exception {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_15",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "88888888-compute@developer.gserviceaccount.com"
-                }
-            }
-        }
-    }
+test_not_deny_default_sa_org_member_when_exception if {
+	inp := {"resource": {"google_organization_iam_member": {"public-member": {
+		"//": "TF_GCP_15",
+		"role": "roles/iap.httpsResourceAccessor",
+		"member": "88888888-compute@developer.gserviceaccount.com",
+	}}}}
 
-    t.no_errors(deny_default_sa_member_on_org_level) with input as input
+	t.no_errors(deny_default_sa_member_on_org_level) with input as inp
 }
 
-test_deny_default_sa_org_member_more_members {
-    input := {
-        "resource": {
-            "google_organization_iam_member": {
-                "public-member": {
-                    "//": "TF_GCP_15",
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "88888888-compute@developer.gserviceaccount.com"
-                },
-                "should be blocked": {
-                    "role": "roles/iap.httpsResourceAccessor",
-                    "member": "7777777-compute@developer.gserviceaccount.com"
-                }
-            }
-        }
-    }
+test_deny_default_sa_org_member_more_members if {
+	inp := {"resource": {"google_organization_iam_member": {
+		"public-member": {
+			"//": "TF_GCP_15",
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "88888888-compute@developer.gserviceaccount.com",
+		},
+		"should be blocked": {
+			"role": "roles/iap.httpsResourceAccessor",
+			"member": "7777777-compute@developer.gserviceaccount.com",
+		},
+	}}}
 
-    t.error_count(deny_default_sa_member_on_org_level, 1) with input as input
+	t.error_count(deny_default_sa_member_on_org_level, 1) with input as inp
 }

--- a/policy/terraform/gcp/project/deny_google_project_network_auto.rego
+++ b/policy/terraform/gcp/project/deny_google_project_network_auto.rego
@@ -1,12 +1,14 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 import data.terraform
 
 check06 := "TF_GCP_06"
 
 # DENY(TF_GCP_06)
-deny_project_auto_created_network[msg] {
+deny_project_auto_created_network contains msg if {
 	input.resource.google_project
 	p := input.resource.google_project[_]
 	not make_exception(check06, p)

--- a/policy/terraform/gcp/project/deny_google_project_network_auto_test.rego
+++ b/policy/terraform/gcp/project/deny_google_project_network_auto_test.rego
@@ -1,83 +1,54 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.testing as t
 
-test_not_deny_project_auto_created_network_with_exclusions {
-    input := {
-        "resource": {
-            "google_project": {
-                "p": {
-                    "//": "TF_GCP_06",
-                    "name": "p",
-                    "project_id": "project_id"
-                },
-            },
-        },
-    }
+test_not_deny_project_auto_created_network_with_exclusions if {
+	inp := {"resource": {"google_project": {"p": {
+		"//": "TF_GCP_06",
+		"name": "p",
+		"project_id": "project_id",
+	}}}}
 
-    t.no_errors(deny_project_auto_created_network) with input as input
+	t.no_errors(deny_project_auto_created_network) with input as inp
 }
 
-test_deny_project_auto_created_network {
-    input := {
-        "resource": {
-            "google_project": {
-                "p": {
-                    "name": "p",
-                    "project_id": "project_id"
-                },
-            },
-        },
-    }
+test_deny_project_auto_created_network if {
+	inp := {"resource": {"google_project": {"p": {
+		"name": "p",
+		"project_id": "project_id",
+	}}}}
 
-    t.error_count(deny_project_auto_created_network, 1) with input as input
+	t.error_count(deny_project_auto_created_network, 1) with input as inp
 }
 
-test_deny_project_auto_created_network_with_property {
-    input := {
-        "resource": {
-            "google_project": {
-                "p": {
-                    "name": "p",
-                    "project_id": "project_id",
-                    "auto_create_network": true
-                },
-            },
-        },
-    }
+test_deny_project_auto_created_network_with_property if {
+	inp := {"resource": {"google_project": {"p": {
+		"name": "p",
+		"project_id": "project_id",
+		"auto_create_network": true,
+	}}}}
 
-    t.error_count(deny_project_auto_created_network, 1) with input as input
+	t.error_count(deny_project_auto_created_network, 1) with input as inp
 }
 
+test_not_deny_project_auto_created_network if {
+	inp := {"resource": {"google_project": {"p": {
+		"name": "p",
+		"project_id": "project_id",
+		"auto_create_network": false,
+	}}}}
 
-test_not_deny_project_auto_created_network {
-    input := {
-        "resource": {
-            "google_project": {
-                "p": {
-                    "name": "p",
-                    "project_id": "project_id",
-                    "auto_create_network": false,
-                },
-            },
-        },
-    }
-
-   t.no_errors(deny_project_auto_created_network) with input as input
+	t.no_errors(deny_project_auto_created_network) with input as inp
 }
 
-test_not_deny_project_auto_created_network_string {
-    input := {
-        "resource": {
-            "google_project": {
-                "p": {
-                    "name": "p",
-                    "project_id": "project_id",
-                    "auto_create_network": "false",
-                },
-            },
-        },
-    }
+test_not_deny_project_auto_created_network_string if {
+	inp := {"resource": {"google_project": {"p": {
+		"name": "p",
+		"project_id": "project_id",
+		"auto_create_network": "false",
+	}}}}
 
-   t.no_errors(deny_project_auto_created_network) with input as input
+	t.no_errors(deny_project_auto_created_network) with input as inp
 }

--- a/policy/terraform/gcp/terraform.rego
+++ b/policy/terraform/gcp/terraform.rego
@@ -1,18 +1,20 @@
 package terraform_gcp
 
+import rego.v1
+
 import data.lib as l
 
-buckets[bucket] {
+buckets contains bucket if {
 	bucket = input.resource.google_storage_bucket[bucket]
 }
 
-blacklisted_users = ["allUsers", "allAuthenticatedUsers"]
+blacklisted_users := ["allUsers", "allAuthenticatedUsers"]
 
-default_service_account_regexp = ".*-compute@developer.gserviceaccount.com|.*@appspot.gserviceaccount.com|.*@cloudbuild.gserviceaccount.com"
+default_service_account_regexp := ".*-compute@developer.gserviceaccount.com|.*@appspot.gserviceaccount.com|.*@cloudbuild.gserviceaccount.com"
 
-impersonation_roles = ["roles/iam.serviceAccountTokenCreator", "roles/iam.serviceAccountUser"]
+impersonation_roles := ["roles/iam.serviceAccountTokenCreator", "roles/iam.serviceAccountUser"]
 
-make_exception(check, obj) {
+make_exception(check, obj) if {
 	checks := split(obj["//"], ",")
 	l.contains_element(checks, check)
 }

--- a/policy/testing.rego
+++ b/policy/testing.rego
@@ -1,9 +1,11 @@
 package testing
 
-no_errors(target) {
+import rego.v1
+
+no_errors(target) if {
 	count(target) == 0
 }
 
-error_count(target, c) {
+error_count(target, c) if {
 	count(target) == c
 }


### PR DESCRIPTION
### Checklist

* [ x ] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [ x ] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [ x ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

As of conftest v0.60.0, the default version of Rego syntax is v1 [1]. This PR updates all policies to use this syntax. Another breaking change came with this version as well (or rather v0.59.0) [2], where hcl2json will consistently use array when using repeated blocks ([3] and [4]). Current (internal) uses are checked for breaking changed. All files were formatted / pre-processed with `opa fmt --write --v0-v1`

### Related Issues

[1] https://github.com/open-policy-agent/conftest/releases/tag/v0.60.0
[2] https://github.com/open-policy-agent/conftest/releases/tag/v0.59.0
[3] https://github.com/open-policy-agent/conftest/pull/1074
[4] https://github.com/open-policy-agent/conftest/issues/1006