### PR TITLE
feat(K8S-04): mark ComputeClass as cluster-scoped resource

### DIFF
--- a/policy/kubernetes/deny_default_namespace.rego
+++ b/policy/kubernetes/deny_default_namespace.rego
@@ -43,6 +43,7 @@ deny_default_namespace contains msg if {
 		is_mutatingwebhookconfig,
 		is_podsecuritypolicy,
 		is_validatingwebhookconfig,
+		is_computeclass,
 	]
 
 	not valid_namespace

--- a/policy/kubernetes/deny_default_namespace_test.rego
+++ b/policy/kubernetes/deny_default_namespace_test.rego
@@ -49,4 +49,7 @@ test_allow_non_namespaced_kinds if {
 
 	validatingwebhookconfig := {"kind": "ValidatingWebhookConfiguration", "metadata": {"name": "test"}}
 	t.no_errors(deny_default_namespace) with input as validatingwebhookconfig
+
+	computeclass := {"kind": "ComputeClass", "metadata": {"name": "test"}}
+	t.no_errors(deny_default_namespace) with input as computeclass
 }

--- a/policy/kubernetes/kubernetes.rego
+++ b/policy/kubernetes/kubernetes.rego
@@ -49,6 +49,8 @@ is_mutatingwebhookconfig := kind == "MutatingWebhookConfiguration"
 
 is_validatingwebhookconfig := kind == "ValidatingWebhookConfiguration"
 
+is_computeclass := kind == "ComputeClass"
+
 is_job if {
 	true in [kind == "CronJob", kind == "Job"]
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`ComputeClass` is a (GKE-specific) cluster-scoped resource for which K8S-04 should not be checked.
